### PR TITLE
feat: rename MeshPy to BeamMe (badges + readme)

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,12 +34,6 @@
 
 </div>
 
-<div align="center">
-
-⚠️ **Disclaimer**: We are currently in the transition-phase from MeshPy to BeamMe. Therefore, naming is not yet consistent across this repository.
-
-</div>
-
 BeamMe is a general purpose 3D beam finite element input generator written in Python.
 It contains advanced geometry creation and manipulation functions to create complex beam geometries, including a consistent handling of finite rotations.
 It can be used to create input files for the following finite element solvers (adaption to other solvers is easily possibly):
@@ -50,11 +44,11 @@ It can be used to create input files for the following finite element solvers (a
 BeamMe is jointly developed at the [Institute for Mathematics and Computer-Based Simulation (IMCS)](https://www.unibw.de/imcs-en) at the Universität der Bundeswehr München and
 the [Institute for Computational Mechanics (LNM)](https://www.epc.ed.tum.de/lnm/home/) at the Technical University Munich.
 
-- **Website**: https://beamme-py.github.io/beamme/
-- **API Documentation** https://beamme-py.github.io/beamme/api-documentation/beamme.html
-- **Coverage Report** https://beamme-py.github.io/beamme/coverage-report/
-- **Github** https://github.com/beamme-py/beamme
-- **Launch interactively online in Binder** https://mybinder.org/v2/gh/beamme-py/beamme/main
+- **Website:** https://beamme-py.github.io/beamme/
+- **API Documentation:** https://beamme-py.github.io/beamme/api-documentation/beamme.html
+- **Coverage Report:** https://beamme-py.github.io/beamme/coverage-report/
+- **Github:** https://github.com/beamme-py/beamme
+- **Launch interactively online in Binder:** https://mybinder.org/v2/gh/beamme-py/beamme/main
 
 ## Overview <!-- omit from toc -->
 - [Examples](#examples)

--- a/doc/badges/documentation.svg
+++ b/doc/badges/documentation.svg
@@ -1,21 +1,21 @@
-<!-- https://img.shields.io/badge/MeshPy-documentation?label=documentation&color=blue --><svg aria-label="documentation: MeshPy" height="20" role="img" width="144" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
-  <title>documentation: MeshPy</title>
+<!-- https://img.shields.io/badge/BeamMe-documentation?label=documentation&color=blue --><svg aria-label="documentation: BeamMe" height="20" role="img" width="150" xmlns="http://www.w3.org/2000/svg">
+  <title>documentation: BeamMe</title>
   <linearGradient id="s" x2="0" y2="100%">
     <stop offset="0" stop-color="#bbb" stop-opacity=".1"/>
     <stop offset="1" stop-opacity=".1"/>
   </linearGradient>
   <clipPath id="r">
-    <rect fill="#fff" height="20" rx="3" width="144"/>
+    <rect fill="#fff" height="20" rx="3" width="150"/>
   </clipPath>
   <g clip-path="url(#r)">
     <rect fill="#555" height="20" width="93"/>
-    <rect fill="#007ec6" height="20" width="51" x="93"/>
-    <rect fill="url(#s)" height="20" width="144"/>
+    <rect fill="#007ec6" height="20" width="57" x="93"/>
+    <rect fill="url(#s)" height="20" width="150"/>
   </g>
   <g fill="#fff" font-family="Verdana,Geneva,DejaVu Sans,sans-serif" font-size="110" text-anchor="middle" text-rendering="geometricPrecision">
     <text aria-hidden="true" fill="#010101" fill-opacity=".3" textLength="830" transform="scale(.1)" x="475" y="150">documentation</text>
     <text fill="#fff" textLength="830" transform="scale(.1)" x="475" y="140">documentation</text>
-    <text aria-hidden="true" fill="#010101" fill-opacity=".3" textLength="410" transform="scale(.1)" x="1175" y="150">MeshPy</text>
-    <text fill="#fff" textLength="410" transform="scale(.1)" x="1175" y="140">MeshPy</text>
+    <text aria-hidden="true" fill="#010101" fill-opacity=".3" textLength="470" transform="scale(.1)" x="1205" y="150">BeamMe</text>
+    <text fill="#fff" textLength="470" transform="scale(.1)" x="1205" y="140">BeamMe</text>
   </g>
 </svg>

--- a/doc/badges/website.svg
+++ b/doc/badges/website.svg
@@ -1,21 +1,21 @@
-<!-- https://img.shields.io/badge/MeshPy-website?label=website&color=blue --><svg aria-label="website: MeshPy" height="20" role="img" width="104" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
-  <title>website: MeshPy</title>
+<!-- https://img.shields.io/badge/BeamMe-website?label=website&color=blue --><svg aria-label="website: BeamMe" height="20" role="img" width="110" xmlns="http://www.w3.org/2000/svg">
+  <title>website: BeamMe</title>
   <linearGradient id="s" x2="0" y2="100%">
     <stop offset="0" stop-color="#bbb" stop-opacity=".1"/>
     <stop offset="1" stop-opacity=".1"/>
   </linearGradient>
   <clipPath id="r">
-    <rect fill="#fff" height="20" rx="3" width="104"/>
+    <rect fill="#fff" height="20" rx="3" width="110"/>
   </clipPath>
   <g clip-path="url(#r)">
     <rect fill="#555" height="20" width="53"/>
-    <rect fill="#007ec6" height="20" width="51" x="53"/>
-    <rect fill="url(#s)" height="20" width="104"/>
+    <rect fill="#007ec6" height="20" width="57" x="53"/>
+    <rect fill="url(#s)" height="20" width="110"/>
   </g>
   <g fill="#fff" font-family="Verdana,Geneva,DejaVu Sans,sans-serif" font-size="110" text-anchor="middle" text-rendering="geometricPrecision">
     <text aria-hidden="true" fill="#010101" fill-opacity=".3" textLength="430" transform="scale(.1)" x="275" y="150">website</text>
     <text fill="#fff" textLength="430" transform="scale(.1)" x="275" y="140">website</text>
-    <text aria-hidden="true" fill="#010101" fill-opacity=".3" textLength="410" transform="scale(.1)" x="775" y="150">MeshPy</text>
-    <text fill="#fff" textLength="410" transform="scale(.1)" x="775" y="140">MeshPy</text>
+    <text aria-hidden="true" fill="#010101" fill-opacity=".3" textLength="470" transform="scale(.1)" x="805" y="150">BeamMe</text>
+    <text fill="#fff" textLength="470" transform="scale(.1)" x="805" y="140">BeamMe</text>
   </g>
 </svg>


### PR DESCRIPTION
This concludes most of the renaming to beamme for this repo

The only thing missing is to discuss a new citation and how we want to handle the `mpy` object.

Part of #350

(the other svg's were reformatted, that's why they change)