### PR TITLE
Update nightly test time to work with new FourCIPP version

### DIFF
--- a/.github/workflows/check_code.yml
+++ b/.github/workflows/check_code.yml
@@ -2,7 +2,7 @@ name: Code quality
 
 on:
   schedule:
-    - cron: '0 04 * * *'
+    - cron: '0 06 * * *'
   push:
     branches:
       - main

--- a/.github/workflows/check_meshpy_redirects.yml
+++ b/.github/workflows/check_meshpy_redirects.yml
@@ -2,7 +2,7 @@ name: Check MeshPy to BeamMe redirects
 
 on:
   schedule:
-    - cron: "0 4 * * *"
+    - cron: "0 06 * * *"
 
 jobs:
   check-redirects:

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -2,7 +2,7 @@ name: Test suite
 
 on:
   schedule:
-    - cron: '0 04 * * *'
+    - cron: '0 06 * * *'
   push:
     branches:
       - main

--- a/.github/workflows/testing_protected.yml
+++ b/.github/workflows/testing_protected.yml
@@ -2,7 +2,7 @@ name: Protected test suite (can access cubit secrets)
 
 on:
   schedule:
-    - cron: '0 04 * * *'
+    - cron: '0 06 * * *'
   push:
     branches:
       - main


### PR DESCRIPTION
As suggested by @davidrudlstorfer in #436 let's schedule the nightly tests once all nightly jobs of upstream packages (e.g., 4C and FourCIPP) are done.

FourCIPP builds the metadata at `- cron: "0 5 * * *"`, so - cron: "0 6 * * *" should be fine here.

In summer time that should be 8:00 local time in Germany - a little bit earlier would be nice, but let's think about that if the nightly pipeline starts to fail regularly (which I hope it won't) an the BeamMe developers start to work before 8:00.
