### PR TITLE
Move 4C functionality out of core

### DIFF
--- a/src/beamme/core/base_mesh_item.py
+++ b/src/beamme/core/base_mesh_item.py
@@ -42,4 +42,4 @@ class BaseMeshItem:
             self.data = {}
 
         # Global index of this item in a mesh.
-        self.i_global = None
+        self.i_global: None | int = None

--- a/src/beamme/core/element.py
+++ b/src/beamme/core/element.py
@@ -64,10 +64,6 @@ class Element(_BaseMeshItem):
                 "The node that should be replaced is not in the current element"
             )
 
-    def dump_element_specific_section(self, yaml_dict):
-        """Add information of this element to specific section (e.g. STRUCTURE
-        KNOTVECTORS for NURBS elements)."""
-
     def get_vtk(self, vtk_writer_beam, vtk_writer_solid, **kwargs):
         """Add representation of this element to the vtk_writers for solid and
         beam."""

--- a/src/beamme/core/element_volume.py
+++ b/src/beamme/core/element_volume.py
@@ -40,18 +40,6 @@ class VolumeElement(_Element):
         super().__init__(nodes=nodes, material=None, **kwargs)
         self.data = data
 
-    def dump_to_list(self):
-        """Return a dict with the items representing this object."""
-
-        return {
-            "id": self.i_global + 1,
-            "cell": {
-                "type": element_type_to_four_c_string[type(self)],
-                "connectivity": self.nodes,
-            },
-            "data": self.data,
-        }
-
     def get_vtk(self, vtk_writer_beam, vtk_writer_solid, **kwargs):
         """Add the representation of this element to the VTK writer as a
         quad."""
@@ -170,13 +158,3 @@ class VolumeHEX27(VolumeElement):
         25,
         26,
     ]
-
-
-element_type_to_four_c_string = {
-    VolumeHEX8: "HEX8",
-    VolumeHEX20: "HEX20",
-    VolumeHEX27: "HEX27",
-    VolumeTET4: "TET4",
-    VolumeTET10: "TET10",
-    VolumeWEDGE6: "WEDGE6",
-}

--- a/src/beamme/core/geometry_set.py
+++ b/src/beamme/core/geometry_set.py
@@ -39,14 +39,6 @@ from beamme.core.node import Node as _Node
 class GeometrySetBase(_BaseMeshItem):
     """Base class for a geometry set."""
 
-    # Node set names for the input file file.
-    geometry_set_names = {
-        _bme.geo.point: "DNODE",
-        _bme.geo.line: "DLINE",
-        _bme.geo.surface: "DSURFACE",
-        _bme.geo.volume: "DVOL",
-    }
-
     def __init__(
         self, geometry_type: _conf.Geometry, name: str | None = None, **kwargs
     ):
@@ -143,25 +135,6 @@ class GeometrySetBase(_BaseMeshItem):
         raise NotImplementedError(
             'The "get_all_nodes" method has to be overwritten in the derived class'
         )
-
-    def dump_to_list(self):
-        """Return a list with the legacy strings of this geometry set."""
-
-        # Sort nodes based on their global index
-        nodes = sorted(self.get_all_nodes(), key=lambda n: n.i_global)
-
-        if not nodes:
-            raise ValueError("Writing empty geometry sets is not supported")
-
-        return [
-            {
-                "type": "NODE",
-                "node_id": node.i_global + 1,
-                "d_type": self.geometry_set_names[self.geometry_type],
-                "d_id": self.i_global + 1,
-            }
-            for node in nodes
-        ]
 
     def __add__(self, other):
         """Create a new geometry set with the combined geometries from this set

--- a/src/beamme/core/node.py
+++ b/src/beamme/core/node.py
@@ -94,15 +94,6 @@ class Node(_BaseMeshItem):
         """Don't do anything for a standard node, as this node can not be
         rotated."""
 
-    def dump_to_list(self):
-        """Return a list with the legacy string representing this node."""
-
-        return {
-            "id": self.i_global + 1,
-            "COORD": self.coordinates,
-            "data": {"type": "NODE"},
-        }
-
 
 class NodeCosserat(Node):
     """This object represents a Cosserat node in the mesh, i.e., it contains
@@ -152,13 +143,3 @@ class ControlPoint(Node):
 
         # Weight of this node
         self.weight = weight
-
-    def dump_to_list(self):
-        """Return a list with the legacy string representing this control
-        point."""
-
-        return {
-            "id": self.i_global + 1,
-            "COORD": self.coordinates,
-            "data": {"type": "CP", "weight": self.weight},
-        }

--- a/src/beamme/four_c/element_volume.py
+++ b/src/beamme/four_c/element_volume.py
@@ -30,21 +30,3 @@ class SolidRigidSphere(_VolumeElement):
     def __init__(self, **kwargs):
         """Initialize solid sphere object."""
         _VolumeElement.__init__(self, **kwargs)
-
-        self.radius = float(self.data["RADIUS"])
-
-    # TODO this method should be removed!
-    # This method should use the super method of _VolumeElement
-    # but currently this results in a circular import if we use the
-    # element to 4C mappings. Think about a better solution.
-    def dump_to_list(self):
-        """Return a dict with the items representing this object."""
-
-        return {
-            "id": self.i_global + 1,
-            "cell": {
-                "type": "POINT1",
-                "connectivity": self.nodes,
-            },
-            "data": self.data,
-        }

--- a/src/beamme/four_c/input_file_dump_item.py
+++ b/src/beamme/four_c/input_file_dump_item.py
@@ -1,0 +1,254 @@
+# The MIT License (MIT)
+#
+# Copyright (c) 2018-2025 BeamMe Authors
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+"""This file defines functions to dump mesh items for 4C."""
+
+from typing import Any as _Any
+
+from beamme.core.boundary_condition import BoundaryCondition as _BoundaryCondition
+from beamme.core.conf import bme as _bme
+from beamme.core.coupling import Coupling as _Coupling
+from beamme.core.element_volume import VolumeElement as _VolumeElement
+from beamme.core.geometry_set import GeometrySet as _GeometrySet
+from beamme.core.geometry_set import GeometrySetNodes as _GeometrySetNodes
+from beamme.core.node import ControlPoint as _ControlPoint
+from beamme.core.node import Node as _Node
+from beamme.core.nurbs_patch import NURBSPatch as _NURBSPatch
+from beamme.core.nurbs_patch import NURBSSurface as _NURBSSurface
+from beamme.core.nurbs_patch import NURBSVolume as _NURBSVolume
+from beamme.four_c.four_c_types import BeamType as _BeamType
+from beamme.four_c.input_file_mappings import (
+    INPUT_FILE_MAPPINGS as _INPUT_FILE_MAPPINGS,
+)
+
+
+def dump_node(node):
+    """Return the representation of a node in the 4C input file."""
+
+    if isinstance(node, _ControlPoint):
+        return {
+            "id": node.i_global + 1,
+            "COORD": node.coordinates,
+            "data": {"type": "CP", "weight": node.weight},
+        }
+    elif isinstance(node, _Node):
+        return {
+            "id": node.i_global + 1,
+            "COORD": node.coordinates,
+            "data": {"type": "NODE"},
+        }
+    else:
+        raise TypeError(f"Got unexpected item of type {type(node)}")
+
+
+def dump_solid_element(solid_element):
+    """Return a dict with the items representing the given solid element."""
+
+    return {
+        "id": solid_element.i_global + 1,
+        "cell": {
+            "type": _INPUT_FILE_MAPPINGS["element_type_to_four_c_string"][
+                type(solid_element)
+            ],
+            "connectivity": solid_element.nodes,
+        },
+        "data": solid_element.data,
+    }
+
+
+def dump_coupling(coupling):
+    """Return the input file representation of the coupling condition."""
+
+    if isinstance(coupling.data, dict):
+        data = coupling.data
+    else:
+        # In this case we have to check which beams are connected to the node.
+        # TODO: Coupling also makes sense for different beam types, this can
+        # be implemented at some point.
+        nodes = coupling.geometry_set.get_points()
+        connected_elements = [
+            element for node in nodes for element in node.element_link
+        ]
+        element_types = {type(element) for element in connected_elements}
+        if len(element_types) > 1:
+            raise TypeError(
+                f"Expected a single connected type of beam elements, got {element_types}"
+            )
+        element_type = element_types.pop()
+        if element_type.four_c_beam_type is _BeamType.kirchhoff:
+            rotvec = {
+                type(element).four_c_element_data["ROTVEC"]
+                for element in connected_elements
+            }
+            if len(rotvec) > 1 or not rotvec.pop():
+                raise TypeError(
+                    "Couplings for Kirchhoff beams and rotvec==False not yet implemented."
+                )
+
+        data = element_type.get_coupling_dict(coupling.data)
+
+    return {"E": coupling.geometry_set.i_global + 1, **data}
+
+
+def dump_geometry_set(geometry_set):
+    """Return a list with the data describing this set."""
+
+    # Sort nodes based on their global index
+    nodes = sorted(geometry_set.get_all_nodes(), key=lambda n: n.i_global)
+
+    if not nodes:
+        raise ValueError("Writing empty geometry sets is not supported")
+
+    return [
+        {
+            "type": "NODE",
+            "node_id": node.i_global + 1,
+            "d_type": _INPUT_FILE_MAPPINGS["geometry_sets_geometry_to_entry_name"][
+                geometry_set.geometry_type
+            ],
+            "d_id": geometry_set.i_global + 1,
+        }
+        for node in nodes
+    ]
+
+
+def dump_nurbs_patch_knotvectors(input_file, nurbs_patch) -> None:
+    """Set the knot vectors of the NURBS patch in the input file."""
+
+    patch_data: dict[str, _Any] = {
+        "KNOT_VECTORS": [],
+    }
+
+    for dir_manifold in range(nurbs_patch.get_nurbs_dimension()):
+        knotvector = nurbs_patch.knot_vectors[dir_manifold]
+        num_knots = len(knotvector)
+
+        # Check the type of knot vector, in case that the multiplicity of the first and last
+        # knot vectors is not p + 1, then it is a closed (periodic) knot vector, otherwise it
+        # is an open (interpolated) knot vector.
+        knotvector_type = "Interpolated"
+
+        for i in range(nurbs_patch.polynomial_orders[dir_manifold] - 1):
+            if (abs(knotvector[i] - knotvector[i + 1]) > _bme.eps_knot_vector) or (
+                abs(knotvector[num_knots - 2 - i] - knotvector[num_knots - 1 - i])
+                > _bme.eps_knot_vector
+            ):
+                knotvector_type = "Periodic"
+                break
+
+        patch_data["KNOT_VECTORS"].append(
+            {
+                "DEGREE": nurbs_patch.polynomial_orders[dir_manifold],
+                "TYPE": knotvector_type,
+                "KNOTS": [
+                    knot_vector_val
+                    for knot_vector_val in nurbs_patch.knot_vectors[dir_manifold]
+                ],
+            }
+        )
+
+    if "STRUCTURE KNOTVECTORS" in input_file:
+        # Get all existing patches in the input file - they will be added to the
+        # input file again at the end of this function. By doing it this way, the
+        # FourCIPP type converter will be applied to the current patch.
+        # This also means that we apply the type converter again already existing
+        # patches. But, with the usual number of patches and data size, this
+        # should not lead to a measurable performance impact.
+        patches = input_file.pop("STRUCTURE KNOTVECTORS")["PATCHES"]
+    else:
+        patches = []
+
+    patch_data["ID"] = nurbs_patch.i_nurbs_patch + 1
+    patches.append(patch_data)
+    input_file.add({"STRUCTURE KNOTVECTORS": {"PATCHES": patches}})
+
+
+def dump_nurbs_patch_elements(nurbs_patch):
+    """Return a list with all the element definitions contained in this
+    patch."""
+
+    nurbs_type_to_default_four_c_type = {
+        _NURBSSurface: "WALLNURBS",
+        _NURBSVolume: "SOLID",
+    }
+
+    # Check the material
+    nurbs_patch._check_material()
+
+    patch_elements = []
+    j = 0
+
+    for knot_span in nurbs_patch._get_knot_span_iterator():  # TODO better name for this
+        element_cps_ids = nurbs_patch._get_ids_ctrlpts(*knot_span)
+        connectivity = [nurbs_patch.nodes[i] for i in element_cps_ids]
+        num_cp = len(connectivity)
+
+        patch_elements.append(
+            {
+                "id": nurbs_patch.i_global + j + 1,
+                "cell": {
+                    "type": f"NURBS{num_cp}",
+                    "connectivity": connectivity,
+                },
+                "data": {
+                    "type": nurbs_type_to_default_four_c_type[type(nurbs_patch)],
+                    "MAT": nurbs_patch.material,
+                    **(nurbs_patch.data if nurbs_patch.data else {}),
+                },
+            }
+        )
+        j += 1
+
+    return patch_elements
+
+
+def dump_item_to_list(dumped_list, item) -> None:
+    """General function to dump items to a 4C input file."""
+    if hasattr(item, "dump_to_list"):
+        dumped_list.append(item.dump_to_list())
+    elif isinstance(item, _Node):
+        dumped_list.append(dump_node(item))
+    elif isinstance(item, _VolumeElement):
+        dumped_list.append(dump_solid_element(item))
+    elif isinstance(item, _GeometrySet) or isinstance(item, _GeometrySetNodes):
+        dumped_list.extend(dump_geometry_set(item))
+    elif isinstance(item, _NURBSPatch):
+        dumped_list.extend(dump_nurbs_patch_elements(item))
+    elif isinstance(item, _BoundaryCondition):
+        if item.geometry_set.i_global is None:
+            raise ValueError("i_global is not set")
+        dumped_list.append(
+            {
+                "E": item.geometry_set.i_global + 1,
+                **item.data,
+            }
+        )
+    elif isinstance(item, _Coupling):
+        dumped_list.append(dump_coupling(item))
+    else:
+        raise TypeError(f"Could not dump {item}")
+
+
+def dump_item_to_section(input_file, item) -> None:
+    """This function dumps information of mesh items to general input file
+    sections, e.g., knotvectors for NURBS."""
+    if isinstance(item, _NURBSPatch):
+        dump_nurbs_patch_knotvectors(input_file, item)

--- a/src/beamme/four_c/input_file_mappings.py
+++ b/src/beamme/four_c/input_file_mappings.py
@@ -25,75 +25,112 @@ files."""
 from typing import Any as _Any
 
 from beamme.core.conf import bme as _bme
+from beamme.core.element_volume import (
+    VolumeHEX8 as _VolumeHEX8,
+)
+from beamme.core.element_volume import (
+    VolumeHEX20 as _VolumeHEX20,
+)
+from beamme.core.element_volume import (
+    VolumeHEX27 as _VolumeHEX27,
+)
+from beamme.core.element_volume import (
+    VolumeTET4 as _VolumeTET4,
+)
+from beamme.core.element_volume import (
+    VolumeTET10 as _VolumeTET10,
+)
+from beamme.core.element_volume import (
+    VolumeWEDGE6 as _VolumeWEDGE6,
+)
+from beamme.four_c.element_volume import SolidRigidSphere as _SolidRigidSphere
 from beamme.four_c.four_c_types import BeamType as _BeamType
 
-INPUT_FILE_MAPPINGS: dict[str, _Any] = {
-    "beam_types": {
-        _BeamType.reissner: "BEAM3R",
-        _BeamType.kirchhoff: "BEAM3K",
-        _BeamType.euler_bernoulli: "BEAM3EB",
-    },
-    "boundary_conditions": {
-        (_bme.bc.dirichlet, _bme.geo.point): "DESIGN POINT DIRICH CONDITIONS",
-        (_bme.bc.dirichlet, _bme.geo.line): "DESIGN LINE DIRICH CONDITIONS",
-        (_bme.bc.dirichlet, _bme.geo.surface): "DESIGN SURF DIRICH CONDITIONS",
-        (_bme.bc.dirichlet, _bme.geo.volume): "DESIGN VOL DIRICH CONDITIONS",
-        (_bme.bc.locsys, _bme.geo.point): "DESIGN POINT LOCSYS CONDITIONS",
-        (_bme.bc.locsys, _bme.geo.line): "DESIGN LINE LOCSYS CONDITIONS",
-        (_bme.bc.locsys, _bme.geo.surface): "DESIGN SURF LOCSYS CONDITIONS",
-        (_bme.bc.locsys, _bme.geo.volume): "DESIGN VOL LOCSYS CONDITIONS",
-        (_bme.bc.neumann, _bme.geo.point): "DESIGN POINT NEUMANN CONDITIONS",
-        (_bme.bc.neumann, _bme.geo.line): "DESIGN LINE NEUMANN CONDITIONS",
-        (_bme.bc.neumann, _bme.geo.surface): "DESIGN SURF NEUMANN CONDITIONS",
-        (_bme.bc.neumann, _bme.geo.volume): "DESIGN VOL NEUMANN CONDITIONS",
-        (
-            _bme.bc.moment_euler_bernoulli,
-            _bme.geo.point,
-        ): "DESIGN POINT MOMENT EB CONDITIONS",
-        (
-            _bme.bc.beam_to_solid_volume_meshtying,
-            _bme.geo.line,
-        ): "BEAM INTERACTION/BEAM TO SOLID VOLUME MESHTYING LINE",
-        (
-            _bme.bc.beam_to_solid_volume_meshtying,
-            _bme.geo.volume,
-        ): "BEAM INTERACTION/BEAM TO SOLID VOLUME MESHTYING VOLUME",
-        (
-            _bme.bc.beam_to_solid_surface_meshtying,
-            _bme.geo.line,
-        ): "BEAM INTERACTION/BEAM TO SOLID SURFACE MESHTYING LINE",
-        (
-            _bme.bc.beam_to_solid_surface_meshtying,
-            _bme.geo.surface,
-        ): "BEAM INTERACTION/BEAM TO SOLID SURFACE MESHTYING SURFACE",
-        (
-            _bme.bc.beam_to_solid_surface_contact,
-            _bme.geo.line,
-        ): "BEAM INTERACTION/BEAM TO SOLID SURFACE CONTACT LINE",
-        (
-            _bme.bc.beam_to_solid_surface_contact,
-            _bme.geo.surface,
-        ): "BEAM INTERACTION/BEAM TO SOLID SURFACE CONTACT SURFACE",
-        (_bme.bc.point_coupling, _bme.geo.point): "DESIGN POINT COUPLING CONDITIONS",
-        (
-            _bme.bc.beam_to_beam_contact,
-            _bme.geo.line,
-        ): "BEAM INTERACTION/BEAM TO BEAM CONTACT CONDITIONS",
-        (
-            _bme.bc.point_coupling_penalty,
-            _bme.geo.point,
-        ): "DESIGN POINT PENALTY COUPLING CONDITIONS",
-        (
-            "DESIGN SURF MORTAR CONTACT CONDITIONS 3D",
-            _bme.geo.surface,
-        ): "DESIGN SURF MORTAR CONTACT CONDITIONS 3D",
-    },
-    "geometry_sets": {
-        _bme.geo.point: "DNODE-NODE TOPOLOGY",
-        _bme.geo.line: "DLINE-NODE TOPOLOGY",
-        _bme.geo.surface: "DSURF-NODE TOPOLOGY",
-        _bme.geo.volume: "DVOL-NODE TOPOLOGY",
-    },
-    "n_nodes_to_cell_type": {2: "LINE2", 3: "LINE3"},
-    "n_nodes_to_node_ordering": {2: [0, 1], 3: [0, 2, 1]},
+INPUT_FILE_MAPPINGS: dict[str, _Any] = {}
+INPUT_FILE_MAPPINGS["beam_types"] = {
+    _BeamType.reissner: "BEAM3R",
+    _BeamType.kirchhoff: "BEAM3K",
+    _BeamType.euler_bernoulli: "BEAM3EB",
 }
+INPUT_FILE_MAPPINGS["boundary_conditions"] = {
+    (_bme.bc.dirichlet, _bme.geo.point): "DESIGN POINT DIRICH CONDITIONS",
+    (_bme.bc.dirichlet, _bme.geo.line): "DESIGN LINE DIRICH CONDITIONS",
+    (_bme.bc.dirichlet, _bme.geo.surface): "DESIGN SURF DIRICH CONDITIONS",
+    (_bme.bc.dirichlet, _bme.geo.volume): "DESIGN VOL DIRICH CONDITIONS",
+    (_bme.bc.locsys, _bme.geo.point): "DESIGN POINT LOCSYS CONDITIONS",
+    (_bme.bc.locsys, _bme.geo.line): "DESIGN LINE LOCSYS CONDITIONS",
+    (_bme.bc.locsys, _bme.geo.surface): "DESIGN SURF LOCSYS CONDITIONS",
+    (_bme.bc.locsys, _bme.geo.volume): "DESIGN VOL LOCSYS CONDITIONS",
+    (_bme.bc.neumann, _bme.geo.point): "DESIGN POINT NEUMANN CONDITIONS",
+    (_bme.bc.neumann, _bme.geo.line): "DESIGN LINE NEUMANN CONDITIONS",
+    (_bme.bc.neumann, _bme.geo.surface): "DESIGN SURF NEUMANN CONDITIONS",
+    (_bme.bc.neumann, _bme.geo.volume): "DESIGN VOL NEUMANN CONDITIONS",
+    (
+        _bme.bc.moment_euler_bernoulli,
+        _bme.geo.point,
+    ): "DESIGN POINT MOMENT EB CONDITIONS",
+    (
+        _bme.bc.beam_to_solid_volume_meshtying,
+        _bme.geo.line,
+    ): "BEAM INTERACTION/BEAM TO SOLID VOLUME MESHTYING LINE",
+    (
+        _bme.bc.beam_to_solid_volume_meshtying,
+        _bme.geo.volume,
+    ): "BEAM INTERACTION/BEAM TO SOLID VOLUME MESHTYING VOLUME",
+    (
+        _bme.bc.beam_to_solid_surface_meshtying,
+        _bme.geo.line,
+    ): "BEAM INTERACTION/BEAM TO SOLID SURFACE MESHTYING LINE",
+    (
+        _bme.bc.beam_to_solid_surface_meshtying,
+        _bme.geo.surface,
+    ): "BEAM INTERACTION/BEAM TO SOLID SURFACE MESHTYING SURFACE",
+    (
+        _bme.bc.beam_to_solid_surface_contact,
+        _bme.geo.line,
+    ): "BEAM INTERACTION/BEAM TO SOLID SURFACE CONTACT LINE",
+    (
+        _bme.bc.beam_to_solid_surface_contact,
+        _bme.geo.surface,
+    ): "BEAM INTERACTION/BEAM TO SOLID SURFACE CONTACT SURFACE",
+    (_bme.bc.point_coupling, _bme.geo.point): "DESIGN POINT COUPLING CONDITIONS",
+    (
+        _bme.bc.beam_to_beam_contact,
+        _bme.geo.line,
+    ): "BEAM INTERACTION/BEAM TO BEAM CONTACT CONDITIONS",
+    (
+        _bme.bc.point_coupling_penalty,
+        _bme.geo.point,
+    ): "DESIGN POINT PENALTY COUPLING CONDITIONS",
+    (
+        "DESIGN SURF MORTAR CONTACT CONDITIONS 3D",
+        _bme.geo.surface,
+    ): "DESIGN SURF MORTAR CONTACT CONDITIONS 3D",
+}
+INPUT_FILE_MAPPINGS["element_type_to_four_c_string"] = {
+    _VolumeHEX8: "HEX8",
+    _VolumeHEX20: "HEX20",
+    _VolumeHEX27: "HEX27",
+    _VolumeTET4: "TET4",
+    _VolumeTET10: "TET10",
+    _VolumeWEDGE6: "WEDGE6",
+    _SolidRigidSphere: "POINT1",
+}
+INPUT_FILE_MAPPINGS["element_four_c_string_to_type"] = {
+    value: key
+    for key, value in INPUT_FILE_MAPPINGS["element_type_to_four_c_string"].items()
+}
+INPUT_FILE_MAPPINGS["geometry_sets_geometry_to_condition_name"] = {
+    _bme.geo.point: "DNODE-NODE TOPOLOGY",
+    _bme.geo.line: "DLINE-NODE TOPOLOGY",
+    _bme.geo.surface: "DSURF-NODE TOPOLOGY",
+    _bme.geo.volume: "DVOL-NODE TOPOLOGY",
+}
+INPUT_FILE_MAPPINGS["geometry_sets_geometry_to_entry_name"] = {
+    _bme.geo.point: "DNODE",
+    _bme.geo.line: "DLINE",
+    _bme.geo.surface: "DSURFACE",
+    _bme.geo.volume: "DVOL",
+}
+INPUT_FILE_MAPPINGS["n_nodes_to_cell_type"] = {2: "LINE2", 3: "LINE3"}
+INPUT_FILE_MAPPINGS["n_nodes_to_node_ordering"] = {2: [0, 1], 3: [0, 2, 1]}

--- a/tests/test_nurbs.py
+++ b/tests/test_nurbs.py
@@ -157,11 +157,7 @@ def test_nurbs_brick(assert_results_close, get_corresponding_reference_file_path
     mat = MaterialStVenantKirchhoff(youngs_modulus=710, nu=0.19, density=5.3e-7)
 
     # Create patch set
-    patch_set = add_geomdl_nurbs_to_mesh(
-        mesh,
-        vol_obj,
-        material=mat,
-    )
+    patch_set = add_geomdl_nurbs_to_mesh(mesh, vol_obj, material=mat)
 
     mesh.add(patch_set)
 


### PR DESCRIPTION
This draft PR suggests a way to move the last remaining 4C functionality out of core.

Each commit kind of moved one functionality.

We now have this functionalist in the `src/beamme/four_c/input_file_dump.py` file.

This is a draft to discuss is this is a desired solution. If we want this, I think it makes sense to more or less create a PR for each commit since some (e.g., the NURBS one) contain quire some functional changes.