### PR TITLE
Install BeamMe with all dependencies in mybinder

### DIFF
--- a/.binder/Dockerfile
+++ b/.binder/Dockerfile
@@ -36,4 +36,4 @@ RUN chown -R 1000 ${HOME}
 RUN chown -R 1000 ${HOME}/.*
 USER jovyan
 WORKDIR ${HOME}
-RUN pip install -e .
+RUN pip install -e .[fourc,dev]


### PR DESCRIPTION
Install the full beamme package (without cubitpy) in mybinder. This allows to directly run the test suite in a mybinder instance.