### PR TITLE
Allow Cubit tests to fail

### DIFF
--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -47,3 +47,35 @@ jobs:
         with:
           name: ${{ github.job }}-${{ matrix.os-version }}-python${{ matrix.python-version }}-${{ github.run_number }}
           path: ${{ env.PYTEST_TMPDIR }}
+
+  beamme-testing-with-dependencies:
+    name: ubuntu-latest with dependencies 4C and ArborX
+    runs-on: ubuntu-latest
+    container:
+      image: ghcr.io/4c-multiphysics/4c:main
+    defaults:
+      run:
+        shell: bash
+    steps:
+      - name: Checkout PR code
+        uses: actions/checkout@v4
+        with:
+          submodules: true
+      - name: Setup virtual python environment
+        uses: ./.github/actions/setup_virtual_python_environment
+      - name: Build ArborX geometric search
+        uses: ./.github/actions/build_arborx_geometric_search
+      - name: Run the test suite
+        uses: ./.github/actions/run_tests
+        with:
+          source-command: "source python-workflow-venv/bin/activate"
+          install-command: "-e .[dev,fourc]"
+          additional-pytest-flags: "--4C --ArborX --cov-fail-under=93"
+      - name: Upload test results on failure
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ github.job }}-${{ github.run_number }}
+          path: ${{ env.PYTEST_TMPDIR }}
+      - name: Coverage badge and report
+        uses: ./.github/actions/coverage

--- a/.github/workflows/testing_protected.yml
+++ b/.github/workflows/testing_protected.yml
@@ -19,6 +19,7 @@ env:
 jobs:
   beamme-testing-all-dependencies:
     name: ubuntu-latest with all dependencies
+    continue-on-error: true # Set this to true if there are issues with the Cubit workflow
     runs-on: ubuntu-latest
     environment:
       # Use the trusted environment only for PRs authored by an COLLABORATOR (no approval needed); all others use the untrusted environment (someone has to approve the workflow run).
@@ -66,11 +67,10 @@ jobs:
         with:
           name: ${{ github.job }}-${{ github.run_number }}
           path: ${{ env.PYTEST_TMPDIR }}
-      - name: Coverage badge and report
-        uses: ./.github/actions/coverage
 
   beamme-performance-testing:
     needs: beamme-testing-all-dependencies
+    if: needs.beamme-testing-all-dependencies.result == 'success'
     name: performance tests
     continue-on-error: true
     runs-on: ubuntu-latest

--- a/.github/workflows/website.yml
+++ b/.github/workflows/website.yml
@@ -68,14 +68,14 @@ jobs:
       - name: Download coverage report artifact
         uses: dawidd6/action-download-artifact@v8
         with:
-          workflow: testing_protected.yml
+          workflow: testing.yml
           name: coverage-report
           path: ${{ github.workspace }}/coverage-report
           branch: ${{ github.event.repository.default_branch }}
       - name: Download coverage badge artifact
         uses: dawidd6/action-download-artifact@v8
         with:
-          workflow: testing_protected.yml
+          workflow: testing.yml
           name: coverage-badge
           path: ${{ github.workspace }}/coverage-badge
           branch: ${{ github.event.repository.default_branch }}


### PR DESCRIPTION
The Cubit workflow has caused some issues recently. This PR allows for failures of the full dependency test (including CubitPy). To still actively test the other dependencies, a test including 4C and ArborX is added to the unprotected test suite.