### PR TITLE
Add mesh representation

### DIFF
--- a/src/beamme/core/conf.py
+++ b/src/beamme/core/conf.py
@@ -89,6 +89,15 @@ class ElementType(_Enum):
     solid = _auto()
 
 
+class NodeType(_Enum):
+    """Enum for node types."""
+
+    node = _auto()
+    cosserat = _auto()
+    control_point = _auto()
+    space_time_cosserat = _auto()
+
+
 class DoubleNodes(_Enum):
     """Enum for handing double nodes in Neumann conditions."""
 
@@ -105,6 +114,7 @@ class BeamMe(object):
         self.bc = BoundaryCondition
         self.coupling_dof = CouplingDofType
         self.element_type = ElementType
+        self.node_type = NodeType
         self.double_nodes = DoubleNodes
 
     def set_default_values(self):

--- a/src/beamme/core/mesh_representation.py
+++ b/src/beamme/core/mesh_representation.py
@@ -1,0 +1,201 @@
+# The MIT License (MIT)
+#
+# Copyright (c) 2018-2026 BeamMe Authors
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+"""This module defines the mesh representation data structure."""
+
+from dataclasses import dataclass as _dataclass
+from typing import Any as _Any
+
+import numpy as _np
+import pyvista as _pv
+from numpy.typing import NDArray as _NDArray
+
+from beamme.core.conf import Geometry as _Geometry
+from beamme.core.conf import bme as _bme
+
+MESH_REPRESENTATION_MAPPINGS: dict[str, _Any] = {}
+MESH_REPRESENTATION_MAPPINGS[
+    "element_type_and_n_nodes_to_connectivity_mapping_beamme_to_vtk"
+] = {
+    # Only list the non-standard mappings
+    (_bme.element_type.solid, 20): [
+        0,
+        1,
+        2,
+        3,
+        4,
+        5,
+        6,
+        7,
+        8,
+        9,
+        10,
+        11,
+        16,
+        17,
+        18,
+        19,
+        12,
+        13,
+        14,
+        15,
+    ],
+    (_bme.element_type.solid, 27): [
+        0,
+        1,
+        2,
+        3,
+        4,
+        5,
+        6,
+        7,
+        8,
+        9,
+        10,
+        11,
+        16,
+        17,
+        18,
+        19,
+        12,
+        13,
+        14,
+        15,
+        24,
+        22,
+        21,
+        23,
+        20,
+        25,
+        26,
+    ],
+}
+MESH_REPRESENTATION_MAPPINGS[
+    "element_type_and_n_nodes_to_connectivity_mapping_vtk_to_beamme"
+] = {
+    # Only list the non-standard mappings
+    (_bme.element_type.solid, 20): _np.argsort(
+        MESH_REPRESENTATION_MAPPINGS[
+            "element_type_and_n_nodes_to_connectivity_mapping_beamme_to_vtk"
+        ][(_bme.element_type.solid, 20)]
+    ),
+    (_bme.element_type.solid, 27): _np.argsort(
+        MESH_REPRESENTATION_MAPPINGS[
+            "element_type_and_n_nodes_to_connectivity_mapping_beamme_to_vtk"
+        ][(_bme.element_type.solid, 27)]
+    ),
+}
+
+GEOMETRY_SET_INFO_PREFIX = "geometry_set"
+
+
+@_dataclass
+class GeometrySetInfo:
+    """Data class that contains information of a geometry set."""
+
+    geometry_type: _Geometry
+    i_global: int
+    name: str | None = None
+    point_flag_vector: _NDArray | None = None
+    cell_flag_vector: _NDArray | None = None
+
+    def __str__(self):
+        """Return a string representation of this geometry set info - the node and cell flags are not included."""
+        name = self.name
+        return (
+            f"{GEOMETRY_SET_INFO_PREFIX}_{self.i_global}_{self.geometry_type.name}"
+            + (f"_{name}" if name is not None else "")
+        )
+
+
+def string_to_geometry_set_info(name: str) -> GeometrySetInfo | None:
+    """Extract the geometry set information from a given string."""
+    if not name.startswith(GEOMETRY_SET_INFO_PREFIX):
+        return None
+
+    name_without_prefix = name[len(GEOMETRY_SET_INFO_PREFIX) + 1 :]
+    split = name_without_prefix.split("_", 2)
+    i_global = int(split[0])
+    geometry_type = _Geometry[split[1]]
+    return GeometrySetInfo(
+        i_global=i_global,
+        geometry_type=geometry_type,
+        name=split[2] if len(split) == 3 else None,
+    )
+
+
+class MeshRepresentation:
+    """Class representing a generic mesh."""
+
+    def __init__(
+        self,
+        cell_connectivity: _NDArray[_np.integer] | None = None,
+        cell_types: _NDArray[_np.integer] | None = None,
+        points: _NDArray[_np.floating] | None = None,
+        geometry_sets: list[GeometrySetInfo] | None = None,
+        cell_data: dict[str, _NDArray | None] | None = None,
+        point_data: dict[str, _NDArray | None] | None = None,
+    ):
+        if cell_connectivity is None or len(cell_connectivity) == 0:
+            # In this case, we have an empty mesh representation.
+            # Safety check that all provided data is None or empty
+            if (
+                (cell_types is not None and len(cell_types) > 0)
+                or (points is not None and len(points) > 0)
+                or (geometry_sets is not None and len(geometry_sets) > 0)
+                or (cell_data is not None and len(cell_data) > 0)
+                or (point_data is not None and len(point_data) > 0)
+            ):
+                raise ValueError(
+                    "If cell_connectivity is None or empty, all other data must be None or empty as well."
+                )
+            self._grid = None
+        else:
+            # We use a unstructured vtk grid as main mesh data structure
+            self._grid = _pv.UnstructuredGrid(cell_connectivity, cell_types, points)
+
+            # Store node set information
+            if geometry_sets is not None:
+                for node_set in geometry_sets:
+                    self._grid.point_data[str(node_set)] = node_set.point_flag_vector
+
+            # Store the required data in the grid.
+            for data, attribute_name in (
+                (cell_data, "cell_data"),
+                (point_data, "point_data"),
+            ):
+                if data is not None:
+                    data_attribute = getattr(self._grid, attribute_name)
+                    for key, value in data.items():
+                        if value is not None:
+                            data_attribute[key] = value
+
+    def is_empty(self) -> bool:
+        """Return True if this mesh representation is empty, i.e., it does not
+        contain any grid."""
+        return self._grid is None
+
+    @property
+    def grid(self) -> _pv.UnstructuredGrid:
+        """Return the internal grid of this mesh representation."""
+        if self.is_empty():
+            raise ValueError("This mesh representation does not contain a grid.")
+        return self._grid

--- a/src/beamme/core/mesh_representation.py
+++ b/src/beamme/core/mesh_representation.py
@@ -32,62 +32,19 @@ from beamme.core.conf import Geometry as _Geometry
 from beamme.core.conf import bme as _bme
 
 MESH_REPRESENTATION_MAPPINGS: dict[str, _Any] = {}
+# fmt: off
 MESH_REPRESENTATION_MAPPINGS[
     "element_type_and_n_nodes_to_connectivity_mapping_beamme_to_vtk"
 ] = {
+
     # Only list the non-standard mappings
-    (_bme.element_type.solid, 20): [
-        0,
-        1,
-        2,
-        3,
-        4,
-        5,
-        6,
-        7,
-        8,
-        9,
-        10,
-        11,
-        16,
-        17,
-        18,
-        19,
-        12,
-        13,
-        14,
-        15,
-    ],
-    (_bme.element_type.solid, 27): [
-        0,
-        1,
-        2,
-        3,
-        4,
-        5,
-        6,
-        7,
-        8,
-        9,
-        10,
-        11,
-        16,
-        17,
-        18,
-        19,
-        12,
-        13,
-        14,
-        15,
-        24,
-        22,
-        21,
-        23,
-        20,
-        25,
-        26,
-    ],
+    (_bme.element_type.solid, 20):
+        [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 16, 17, 18, 19, 12, 13, 14, 15],
+    (_bme.element_type.solid, 27):
+        [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 16, 17, 18, 19, 12, 13, 14, 15,
+         24, 22, 21, 23, 20, 25, 26],
 }
+# fmt: on
 MESH_REPRESENTATION_MAPPINGS[
     "element_type_and_n_nodes_to_connectivity_mapping_vtk_to_beamme"
 ] = {

--- a/src/beamme/four_c/input_file.py
+++ b/src/beamme/four_c/input_file.py
@@ -487,3 +487,12 @@ class InputFile:
             application_script_lines.extend("# " + line for line in script_file)
 
         return application_script_lines
+
+    def contains_external_mesh_based_geometry(self) -> bool:
+        """Check if the input file contains external mesh-based geometry.
+
+        Returns:
+            True if the input file contains external mesh-based geometry, False otherwise.
+        """
+
+        return False

--- a/src/beamme/four_c/input_file_mappings.py
+++ b/src/beamme/four_c/input_file_mappings.py
@@ -24,7 +24,12 @@ files."""
 
 from typing import Any as _Any
 
+import pyvista as _pv
+
 from beamme.core.conf import bme as _bme
+from beamme.core.mesh_representation import (
+    MESH_REPRESENTATION_MAPPINGS as _MESH_REPRESENTATION_MAPPINGS,
+)
 from beamme.four_c.four_c_types import BeamType as _BeamType
 from beamme.utils.data_structures import (
     create_inverse_mapping as _create_inverse_mapping,
@@ -51,26 +56,41 @@ INPUT_FILE_MAPPINGS["element_type_and_n_nodes_to_four_c_cell"] = {
     (_bme.element_type.solid, 6): "WEDGE6",
     (_bme.element_type.solid, 1): "POINT1",
 }
-INPUT_FILE_MAPPINGS["four_c_type_and_cell_to_beamme_element_type"] = {
-    ("SOLID", "HEX8"): _bme.element_type.solid,
-    ("SOLID", "HEX20"): _bme.element_type.solid,
-    ("SOLID", "HEX27"): _bme.element_type.solid,
-    ("SOLID", "TET4"): _bme.element_type.solid,
-    ("SOLID", "TET10"): _bme.element_type.solid,
-    ("SOLID", "WEDGE6"): _bme.element_type.solid,
-    ("RIGIDSPHERE", "POINT1"): _bme.element_type.solid,
+INPUT_FILE_MAPPINGS["four_c_cell_to_element_type_and_n_nodes"] = (
+    _create_inverse_mapping(
+        INPUT_FILE_MAPPINGS["element_type_and_n_nodes_to_four_c_cell"]
+    )
+)
+INPUT_FILE_MAPPINGS["four_c_cell_to_vtk_cell_type"] = {
+    "POINT1": _pv.CellType.VERTEX,
+    "HEX8": _pv.CellType.HEXAHEDRON,
+    "TET4": _pv.CellType.TETRA,
+    "TET10": _pv.CellType.QUADRATIC_TETRA,
+    "HEX20": _pv.CellType.QUADRATIC_HEXAHEDRON,
+    "HEX27": _pv.CellType.TRIQUADRATIC_HEXAHEDRON,
+    "WEDGE6": _pv.CellType.WEDGE,
+}
+# TODO: This can be removed once we have fully switched to mesh representation
+INPUT_FILE_MAPPINGS["beam_n_nodes_to_four_c_ordering"] = {
+    2: [0, 1],
+    3: [0, 2, 1],
+    4: [0, 3, 1, 2],
+    5: [0, 4, 1, 2, 3],
+}
+INPUT_FILE_MAPPINGS["four_c_cell_to_vtk_connectivity_mapping"] = {
+    # Only list the non-standard mappings
+    "HEX20": _MESH_REPRESENTATION_MAPPINGS[
+        "element_type_and_n_nodes_to_connectivity_mapping_vtk_to_beamme"
+    ][(_bme.element_type.solid, 20)],
+    "HEX27": _MESH_REPRESENTATION_MAPPINGS[
+        "element_type_and_n_nodes_to_connectivity_mapping_vtk_to_beamme"
+    ][(_bme.element_type.solid, 27)],
 }
 INPUT_FILE_MAPPINGS["geometry_sets_geometry_to_entry_name"] = {
     _bme.geo.point: "DNODE",
     _bme.geo.line: "DLINE",
     _bme.geo.surface: "DSURFACE",
     _bme.geo.volume: "DVOL",
-}
-INPUT_FILE_MAPPINGS["beam_n_nodes_to_four_c_ordering"] = {
-    2: [0, 1],
-    3: [0, 2, 1],
-    4: [0, 3, 1, 2],
-    5: [0, 4, 1, 2, 3],
 }
 INPUT_FILE_MAPPINGS["boundary_conditions"] = {
     (_bme.bc.dirichlet, _bme.geo.point): "DESIGN POINT DIRICH CONDITIONS",
@@ -142,3 +162,7 @@ INPUT_FILE_MAPPINGS["geometry_sets_condition_to_geometry_name"] = (
         INPUT_FILE_MAPPINGS["geometry_sets_geometry_to_condition_name"]
     )
 )
+INPUT_FILE_MAPPINGS["four_c_node_type_to_beamme_node_type"] = {
+    "NODE": _bme.node_type.node,
+    "CP": _bme.node_type.control_point,
+}

--- a/src/beamme/four_c/model_importer.py
+++ b/src/beamme/four_c/model_importer.py
@@ -25,14 +25,25 @@ from collections import defaultdict as _defaultdict
 from pathlib import Path as _Path
 from typing import Tuple as _Tuple
 
+import numpy as _np
+
 from beamme.core.boundary_condition import BoundaryCondition as _BoundaryCondition
 from beamme.core.boundary_condition import (
     BoundaryConditionBase as _BoundaryConditionBase,
 )
+from beamme.core.conf import Geometry as _Geometry
 from beamme.core.conf import bme as _bme
 from beamme.core.coupling import Coupling as _Coupling
 from beamme.core.geometry_set import GeometrySetNodes as _GeometrySetNodes
 from beamme.core.mesh import Mesh as _Mesh
+from beamme.core.mesh_representation import (
+    MESH_REPRESENTATION_MAPPINGS as _MESH_REPRESENTATION_MAPPINGS,
+)
+from beamme.core.mesh_representation import GeometrySetInfo as _GeometrySetInfo
+from beamme.core.mesh_representation import MeshRepresentation as _MeshRepresentation
+from beamme.core.mesh_representation import (
+    string_to_geometry_set_info as _string_to_geometry_set_info,
+)
 from beamme.core.node import Node as _Node
 from beamme.four_c.element_solid import get_four_c_solid as _get_four_c_solid
 from beamme.four_c.input_file import InputFile as _InputFile
@@ -49,6 +60,38 @@ if _cubitpy_is_available():
     from cubitpy.cubit_to_fourc_input import (
         get_input_file_with_mesh as _get_input_file_with_mesh,
     )
+
+
+class UniqueDataTracker:
+    """Helper class to track unique data dictionaries and assign IDs to them.
+
+    When importing input files, we need to identify elements of the same
+    type. The type information is given in dictionaries. This class
+    provides a tracker that can be queried with a given element data and
+    return an already matching element type ID or create a new one.
+    """
+
+    def __init__(self):
+        self.unique_id_to_data: dict[int, dict] = {}
+
+    def get_unique_id(self, data: dict) -> int:
+        """Get the unique ID for the given data. If the data has not been seen
+        before, a new ID will be assigned to it.
+
+        Args:
+            data: The data dictionary to get the ID for.
+
+        Returns:
+            The unique ID for the given data.
+        """
+        for unique_id, seen_data in self.unique_id_to_data.items():
+            if _compare_nested_dicts_or_lists(data, seen_data):
+                return unique_id
+
+        # If we reach this point, the data has not been seen before. We assign a new ID to it.
+        new_unique_id = len(self.unique_id_to_data)
+        self.unique_id_to_data[new_unique_id] = data
+        return new_unique_id
 
 
 def import_cubitpy_model(
@@ -74,7 +117,7 @@ def import_cubitpy_model(
     input_file.add(_get_input_file_with_mesh(cubit).sections)
 
     if convert_input_to_mesh:
-        return _extract_mesh_sections(input_file)
+        return _extract_mesh_from_input_file(input_file)
     else:
         return input_file, _Mesh()
 
@@ -100,12 +143,12 @@ def import_four_c_model(
     input_file = _InputFile().from_4C_yaml(input_file_path=input_file_path)
 
     if convert_input_to_mesh:
-        return _extract_mesh_sections(input_file)
+        return _extract_mesh_from_input_file(input_file)
     else:
         return input_file, _Mesh()
 
 
-def _extract_mesh_sections(input_file: _InputFile) -> _Tuple[_InputFile, _Mesh]:
+def _extract_mesh_from_input_file(input_file: _InputFile) -> tuple[_InputFile, _Mesh]:
     """Convert an InputFile into a native mesh by translating sections like
     materials, nodes, elements, geometry sets, and boundary conditions.
 
@@ -115,17 +158,331 @@ def _extract_mesh_sections(input_file: _InputFile) -> _Tuple[_InputFile, _Mesh]:
         A tuple (input_file, mesh). The input_file is modified in place to remove
         sections converted into BeamMe objects.
     """
+    if input_file.contains_external_mesh_based_geometry():
+        raise NotImplementedError(
+            "Importing external mesh-based geometry from 4C input files "
+            "is not yet implemented."
+        )
+    else:
+        (
+            mesh_representation,
+            element_type_id_to_data,
+            node_set_internal_id_to_legacy_id,
+        ) = _extract_mesh_representation(input_file)
+    return _create_mesh_from_mesh_representation(
+        input_file,
+        mesh_representation,
+        element_type_id_to_data,
+        node_set_internal_id_to_legacy_id,
+    )
 
-    # function to pop sections from the input file
-    _pop_section = lambda name: input_file.pop(name, [])
+
+def _extract_mesh_representation(
+    input_file: _InputFile,
+) -> tuple[_MeshRepresentation, dict[int, dict], dict[int, int]]:
+    """Extract the mesh representation from mesh data directly contained in the
+    input file.
+
+    This will do an inplace removal the mesh data from the provided input file.
+
+    Args:
+        input_file: The input file containing the mesh data, will be modified in place.
+
+    Returns:
+        A tuple (mesh_representation, element_type_id_to_data, node_set_internal_id_to_legacy_id).
+        - `mesh_representation`: Contains the mesh data extracted from the input file.
+        - `element_type_id_to_data`: A mapping between the element type ID and the element data.
+        - `node_set_internal_id_to_legacy_id`: A mapping that can be used to map the IDs in the mesh representation to legacy node set IDs.
+    """
+
+    # extract nodes
+    nodes = input_file.pop("NODE COORDS", [])
+    n_nodes = len(nodes)
+    points = _np.zeros((n_nodes, 3))
+    point_types = _np.full(n_nodes, -1)
+    control_point_weights = _np.full(n_nodes, -1.0)
+    for i, node in enumerate(nodes):
+        four_c_node_type = node["data"]["type"]
+        node_id = node["id"]
+        try:
+            node_type = _INPUT_FILE_MAPPINGS["four_c_node_type_to_beamme_node_type"][
+                four_c_node_type
+            ]
+        except KeyError:
+            raise ValueError(
+                f"Unknown node type `{four_c_node_type}` for node {node_id}."
+            )
+        points[i] = node["COORD"]
+        point_types[i] = node_type.value
+        if node_type == _bme.node_type.control_point:
+            control_point_weights[i] = node["data"]["weight"]
+
+    # extract elements
+    element_type_tracker = UniqueDataTracker()
+    elements = input_file.pop("STRUCTURE ELEMENTS", [])
+    n_elements = len(elements)
+    cell_connectivity = []
+    cell_types = _np.full(n_elements, -1)
+    cell_element_type_ids = _np.full(n_elements, -1)
+    cell_material_ids = _np.full(n_elements, -1)
+    for i_element, input_element in enumerate(elements):
+        # At this point `input_element` contains the full element data. We can not
+        # compare this directly with the other block data dictionaries, we first
+        # need to extract connectivity and cell ID.
+        element_id = input_element.pop("id")
+        connectivity = (
+            _np.array(input_element["cell"].pop("connectivity"), dtype=int) - 1
+        )
+        material_id = input_element["data"].pop("MAT", -1)
+
+        # Get the cell type, but keep it in the input element data
+        four_c_cell_type = input_element["cell"]["type"]
+
+        # Get the id of the current element
+        element_type_id = element_type_tracker.get_unique_id(input_element)
+
+        # Check if connectivity has to be reordered
+        reorder_indices = _INPUT_FILE_MAPPINGS[
+            "four_c_cell_to_vtk_connectivity_mapping"
+        ].get(four_c_cell_type, None)
+        if reorder_indices is not None:
+            connectivity = connectivity[reorder_indices]
+
+        cell_connectivity.extend([len(connectivity), *connectivity.tolist()])
+
+        try:
+            vtk_cell_type = _INPUT_FILE_MAPPINGS["four_c_cell_to_vtk_cell_type"][
+                four_c_cell_type
+            ]
+        except KeyError:
+            raise ValueError(
+                f"Unknown cell type `{four_c_cell_type}` for element {element_id}."
+            )
+
+        cell_types[i_element] = vtk_cell_type
+        cell_element_type_ids[i_element] = element_type_id
+        cell_material_ids[i_element] = material_id
+
+    # extract geometry sets
+    node_sets: list[_GeometrySetInfo] = []
+    node_set_internal_id_to_legacy_id: dict[int, int] = {}
+    for section_name in input_file.sections:
+        if not section_name.endswith("TOPOLOGY"):
+            continue
+
+        items = input_file.pop(section_name, [])
+        if not items:
+            continue
+
+        # Find geometry type for this section
+        try:
+            geometry_type = _INPUT_FILE_MAPPINGS[
+                "geometry_sets_condition_to_geometry_name"
+            ][section_name]
+        except KeyError as e:
+            raise ValueError(f"Unknown geometry section: {section_name}") from e
+
+        # Extract geometry set indices
+        geom_dict: dict[int, set[int]] = _defaultdict(set)
+        for entry in items:
+            geom_dict[entry["d_id"]].add(entry["node_id"] - 1)
+
+        for legacy_node_set_id, node_ids in geom_dict.items():
+            node_set_id = len(node_sets)
+
+            node_set_flag = _np.zeros(n_nodes, dtype=int)
+            node_set_flag[list(node_ids)] = 1
+
+            node_sets.append(
+                _GeometrySetInfo(
+                    geometry_type=geometry_type,
+                    i_global=node_set_id,
+                    point_flag_vector=node_set_flag,
+                )
+            )
+
+            node_set_internal_id_to_legacy_id[node_set_id] = legacy_node_set_id
+
+    # Create the mesh representation and add the extracted data to it.
+    mesh_representation = _MeshRepresentation(
+        cell_connectivity=cell_connectivity,
+        cell_types=cell_types,
+        points=points,
+        geometry_sets=node_sets,
+        point_data={
+            "point_type": point_types,
+            "control_point_weight": control_point_weights,
+        },
+        cell_data={
+            "element_type_id": cell_element_type_ids,
+            "material_id": cell_material_ids,
+        },
+    )
+
+    return (
+        mesh_representation,
+        element_type_tracker.unique_id_to_data,
+        node_set_internal_id_to_legacy_id,
+    )
+
+
+def _create_mesh_from_mesh_representation(
+    input_file,
+    mesh_representation,
+    element_type_id_to_data,
+    node_set_internal_id_to_legacy_id,
+) -> tuple[_InputFile, _Mesh]:
+    """Extract a BeamMe mesh from a mesh representation.
+
+    Args:
+        input_file: The input file containing general data.
+        mesh_representation: The mesh representation to convert.
+        node_set_internal_id_to_legacy_id: A mapping of the mesh representation
+            internal node set IDs to legacy node set IDs, which can be used to
+            link the geometry sets in the input file to the node sets in the mesh
+            representation.
+
+    Returns:
+        A tuple (input_file, mesh). The input_file is modified in place to remove
+        sections converted into the BeamMe mesh.
+    """
 
     # convert all sections to native objects and add to a new mesh
     mesh = _Mesh()
 
     # extract materials
+    material_id_map = _extract_materials_from_input_file(input_file)
+    mesh.materials.extend(material_id_map.values())
+
+    # extract nodes
+    #   For some reason, it is very slow to iterate directly over the points in
+    #   the mesh representation. It is much faster to get a numpy array with
+    #   the point coordinates and iterate over that instead.
+    point_coordinates = _np.array(mesh_representation.grid.points)
+    for node_coordinates, node_type in zip(
+        point_coordinates, mesh_representation.grid.point_data["point_type"]
+    ):
+        if node_type == _bme.node_type.node.value:
+            mesh.nodes.append(_Node(node_coordinates))
+        else:
+            raise ValueError(
+                f"Mesh conversion for node type {_bme.node_type(node_type).name} is not implemented!"
+            )
+
+    # extract elements
+    ## first create the element types
+    element_type_id_to_element_type: dict[int, type] = {}
+    for (
+        element_type_id,
+        element_data,
+    ) in element_type_id_to_data.items():
+        # We can modify this in place here, as `element_type_id_to_data` is not used anymore after this function.
+        four_c_type = element_data["data"].pop("type")
+        four_c_cell_type = element_data["cell"]["type"]
+        element_type, n_nodes = _INPUT_FILE_MAPPINGS[
+            "four_c_cell_to_element_type_and_n_nodes"
+        ][four_c_cell_type]
+        if not element_type == _bme.element_type.solid:
+            raise ValueError(
+                f"Mesh conversion for element type {element_type} is not implemented!"
+            )
+        element_type_id_to_element_type[element_type_id] = _get_four_c_solid(
+            element_type,
+            four_c_type,
+            n_nodes=n_nodes,
+            element_technology=element_data["data"],
+        )
+
+    ## Loop over the elements and create the mesh elements with the correct type, connectivity and material.
+    cell_connectivity = mesh_representation.grid.cell_connectivity
+    offsets = mesh_representation.grid.offset
+    cell_element_type_ids = mesh_representation.grid.cell_data["element_type_id"]
+    cell_material_ids = mesh_representation.grid.cell_data["material_id"]
+    for i_cell, (cell_element_type_id_, material_id) in enumerate(
+        zip(cell_element_type_ids, cell_material_ids)
+    ):
+        connectivity = cell_connectivity[offsets[i_cell] : offsets[i_cell + 1]]
+
+        element_type = element_type_id_to_element_type[cell_element_type_id_]
+
+        reorder_indices = _MESH_REPRESENTATION_MAPPINGS[
+            "element_type_and_n_nodes_to_connectivity_mapping_vtk_to_beamme"
+        ].get((element_type.element_type, len(connectivity)), None)
+        if reorder_indices is not None:
+            nodes = [mesh.nodes[connectivity[i]] for i in reorder_indices]
+        else:
+            nodes = [mesh.nodes[i] for i in connectivity]
+
+        element = element_type(nodes=nodes)
+
+        if not material_id == -1:
+            element.material = material_id_map[material_id]
+        mesh.elements.append(element)
+
+    # extract geometry sets
+    geometry_sets_in_sections: dict[_Geometry, dict[int, _GeometrySetNodes]] = (
+        _defaultdict(dict)
+    )
+    for name in mesh_representation.grid.point_data.keys():
+        info = _string_to_geometry_set_info(name)
+        if info is not None:
+            node_indices = _np.nonzero(mesh_representation.grid.point_data[name])[0]
+            geometry_type = info.geometry_type
+            geometry_set = _GeometrySetNodes(
+                geometry_type, nodes=[mesh.nodes[i] for i in node_indices]
+            )
+            legacy_id = node_set_internal_id_to_legacy_id[info.i_global]
+            geometry_sets_in_sections[geometry_type][legacy_id] = geometry_set
+            mesh.add(geometry_set)
+
+    # extract boundary conditions
+    _standard_bc_types = (
+        _bme.bc.dirichlet,
+        _bme.bc.neumann,
+        _bme.bc.locsys,
+        _bme.bc.beam_to_solid_surface_meshtying,
+        _bme.bc.beam_to_solid_surface_contact,
+        _bme.bc.beam_to_solid_volume_meshtying,
+    )
+
+    for (bc_key, geometry_type), section_name in _INPUT_FILE_MAPPINGS[
+        "boundary_conditions"
+    ].items():
+        for bc_data in input_file.pop(section_name, []):
+            geometry_set = geometry_sets_in_sections[geometry_type][bc_data.pop("E")]
+
+            bc_obj: _BoundaryConditionBase
+
+            if bc_key in _standard_bc_types or isinstance(bc_key, str):
+                bc_obj = _BoundaryCondition(geometry_set, bc_data, bc_type=bc_key)
+            elif bc_key is _bme.bc.point_coupling:
+                bc_obj = _Coupling(
+                    geometry_set, bc_key, bc_data, check_overlapping_nodes=False
+                )
+            else:
+                raise ValueError(f"Unexpected boundary condition: {bc_key}")
+
+            mesh.boundary_conditions.append((bc_key, geometry_type), bc_obj)
+
+    return input_file, mesh
+
+
+def _extract_materials_from_input_file(
+    input_file: _InputFile,
+) -> dict[int, _MaterialSolid]:
+    """Extract all materials from the input file and convert them to BeamMe
+    materials.
+
+    Args:
+        input_file: The input file containing the material sections.
+
+    Returns:
+        A mapping of material IDs to BeamMe material objects.
+    """
+
     material_id_map_all = {}
 
-    for mat in _pop_section("MATERIALS"):
+    for mat in input_file.pop("MATERIALS", []):
         mat_id = mat.pop("MAT")
         if len(mat) != 1:
             raise ValueError(
@@ -157,111 +514,5 @@ def _extract_mesh_sections(input_file: _InputFile) -> _Tuple[_InputFile, _Mesh]:
         for key, val in material_id_map_all.items()
         if key not in nested_materials
     }
-    mesh.materials.extend(material_id_map.values())
 
-    # extract nodes
-    mesh.nodes = [_Node(node["COORD"]) for node in _pop_section("NODE COORDS")]
-
-    # extract elements
-    element_types: dict[type, dict] = {}
-    for input_element in _pop_section("STRUCTURE ELEMENTS"):
-        # At this point `input_element` contains the full element data. We can not
-        # compare this directly with the other block data dictionaries, we first
-        # need to extract connectivity, cell ID and material information from
-        # `input_element`.
-        input_element.pop("id")
-        connectivity = input_element["cell"].pop("connectivity")
-        four_c_type = input_element["data"].pop("type")
-        material_id = input_element["data"].pop("MAT", None)
-
-        four_c_cell_type = input_element["cell"].get("type")
-        beamme_element_type = _INPUT_FILE_MAPPINGS[
-            "four_c_type_and_cell_to_beamme_element_type"
-        ][four_c_type, four_c_cell_type]
-
-        # Loop over already found block element types and check if the current
-        # element matches one of those. If not, create a new block element type
-        # for this element.
-        for element_type, type_data in element_types.items():
-            if _compare_nested_dicts_or_lists(type_data, input_element):
-                break
-        else:
-            element_type = _get_four_c_solid(
-                beamme_element_type,
-                four_c_type,
-                n_nodes=len(connectivity),
-                element_technology=input_element["data"],
-            )
-            element_types[element_type] = input_element
-
-        nodes = [mesh.nodes[i - 1] for i in connectivity]
-        element = element_type(nodes=nodes)
-        if material_id is not None:
-            element.material = material_id_map[material_id]
-        mesh.elements.append(element)
-
-    # extract geometry sets
-    geometry_sets_in_sections: dict[str, dict[int, _GeometrySetNodes]] = _defaultdict(
-        dict
-    )
-
-    for section_name in input_file.sections:
-        if not section_name.endswith("TOPOLOGY"):
-            continue
-
-        items = _pop_section(section_name)
-        if not items:
-            continue
-
-        # Find geometry type for this section
-        try:
-            geometry_type = _INPUT_FILE_MAPPINGS[
-                "geometry_sets_condition_to_geometry_name"
-            ][section_name]
-        except ValueError as e:
-            raise ValueError(f"Unknown geometry section: {section_name}") from e
-
-        # Extract geometry set indices
-        geom_dict: dict[int, list[int]] = _defaultdict(list)
-        for entry in items:
-            geom_dict[entry["d_id"]].append(entry["node_id"] - 1)
-
-        geometry_sets_in_sections[geometry_type] = {
-            gid: _GeometrySetNodes(geometry_type, nodes=[mesh.nodes[i] for i in ids])
-            for gid, ids in geom_dict.items()
-        }
-
-        mesh.geometry_sets[geometry_type] = list(
-            geometry_sets_in_sections[geometry_type].values()
-        )
-
-    # extract boundary conditions
-    _standard_bc_types = (
-        _bme.bc.dirichlet,
-        _bme.bc.neumann,
-        _bme.bc.locsys,
-        _bme.bc.beam_to_solid_surface_meshtying,
-        _bme.bc.beam_to_solid_surface_contact,
-        _bme.bc.beam_to_solid_volume_meshtying,
-    )
-
-    for (bc_key, geometry_type), section_name in _INPUT_FILE_MAPPINGS[
-        "boundary_conditions"
-    ].items():
-        for bc_data in _pop_section(section_name):
-            geometry_set = geometry_sets_in_sections[geometry_type][bc_data.pop("E")]
-
-            bc_obj: _BoundaryConditionBase
-
-            if bc_key in _standard_bc_types or isinstance(bc_key, str):
-                bc_obj = _BoundaryCondition(geometry_set, bc_data, bc_type=bc_key)
-            elif bc_key is _bme.bc.point_coupling:
-                bc_obj = _Coupling(
-                    geometry_set, bc_key, bc_data, check_overlapping_nodes=False
-                )
-            else:
-                raise ValueError(f"Unexpected boundary condition: {bc_key}")
-
-            mesh.boundary_conditions.append((bc_key, geometry_type), bc_obj)
-
-    return input_file, mesh
+    return material_id_map

--- a/src/beamme/four_c/model_importer.py
+++ b/src/beamme/four_c/model_importer.py
@@ -183,7 +183,7 @@ def _extract_mesh_representation(
     """Extract the mesh representation from mesh data directly contained in the
     input file.
 
-    This will do an inplace removal the mesh data from the provided input file.
+    This will do an inplace removal of the mesh data from the provided input file.
 
     Args:
         input_file: The input file containing the mesh data, will be modified in place.
@@ -370,7 +370,7 @@ def _create_mesh_from_mesh_representation(
             )
 
     # extract elements
-    ## first create the element types
+    #   first create the element types
     element_type_id_to_element_type: dict[int, type] = {}
     for (
         element_type_id,
@@ -393,7 +393,7 @@ def _create_mesh_from_mesh_representation(
             element_technology=element_data["data"],
         )
 
-    ## Loop over the elements and create the mesh elements with the correct type, connectivity and material.
+    #   Loop over the elements and create the mesh elements with the correct type, connectivity and material.
     cell_connectivity = mesh_representation.grid.cell_connectivity
     offsets = mesh_representation.grid.offset
     cell_element_type_ids = mesh_representation.grid.cell_data["element_type_id"]

--- a/tests/integration/test_integration_four_c_model_importer.py
+++ b/tests/integration/test_integration_four_c_model_importer.py
@@ -29,7 +29,7 @@ from beamme.core.mesh import Mesh
 from beamme.four_c.element_beam import Beam3rHerm2Line3
 from beamme.four_c.input_file import InputFile
 from beamme.four_c.model_importer import (
-    _extract_mesh_sections,
+    _extract_materials_from_input_file,
     import_cubitpy_model,
     import_four_c_model,
 )
@@ -113,20 +113,20 @@ def test_integration_four_c_model_importer_import_nested_materials(
     input_file = InputFile()
     input_file.add(mesh)
 
-    # Extract the mesh again. Only one material should be present in the extracted mesh.
-    _, mesh_extracted = _extract_mesh_sections(input_file)
-    assert len(mesh_extracted.materials) == 1
+    # Extract the material from the input file. Only one material should be present in the extracted material map.
+    material_id_map = _extract_materials_from_input_file(input_file)
+    assert len(material_id_map) == 1
 
-    # Check that the imported mesh can be added to a mesh that already contains a
+    # Check that the extracted material can be added to a mesh that already contains a
     # material. This tests that the nested materials are correctly relinked during
     # the import.
     mesh_with_other_material = Mesh()
     mesh_with_other_material.add(
         get_default_test_solid_material(material_type="st_venant_kirchhoff")
     )
+    mesh_with_other_material.add(list(material_id_map.values())[0])
     input_file = InputFile()
     input_file.add(mesh_with_other_material)
-    input_file.add(mesh_extracted)
 
     # Compare with reference file.
     assert_results_close(get_corresponding_reference_file_path(), input_file)
@@ -150,7 +150,7 @@ def test_integration_four_c_model_importer_import_nested_materials_error():
             "Material ID 3 not in material_id_map_all (available IDs: [1, 2])."
         ),
     ):
-        _extract_mesh_sections(input_file)
+        _extract_materials_from_input_file(input_file)
 
 
 @pytest.mark.parametrize("full_import", (False, True))


### PR DESCRIPTION
This PR adds a mesh representation to BeamMe. This mesh representation allows for a common interface to BeamMe meshes. For now, we use this mesh representation when importing models in BeamMe.