### PR TITLE
Unify handling of 4C element data

### DIFF
--- a/src/beamme/core/mesh.py
+++ b/src/beamme/core/mesh.py
@@ -726,7 +726,7 @@ class Mesh:
         self,
     ) -> tuple[
         _MeshRepresentation,
-        dict[int, dict],
+        dict[int, _Any],
         dict[_GeometrySetBase, int],
         dict[_Material, int],
         dict[_NURBSPatch, int],

--- a/src/beamme/core/mesh.py
+++ b/src/beamme/core/mesh.py
@@ -25,6 +25,7 @@ elements, sets, ...) for a meshed geometry."""
 import copy as _copy
 import os as _os
 import warnings as _warnings
+from typing import Any as _Any
 from typing import List as _List
 from typing import cast as _cast
 
@@ -812,7 +813,7 @@ class Mesh:
         # Now that we know the expected size, we can allocate the data arrays and
         # actually gather the element data.
         element_type_to_id: dict[type, int] = {}
-        element_type_id_to_data: dict[int, dict] = {}
+        element_type_id_to_data: dict[int, _Any] = {}
         cell_connectivity = []
         cell_types = _np.full(n_elements, -1)
         cell_element_type_ids = _np.full(n_elements, -1)

--- a/src/beamme/four_c/element_beam.py
+++ b/src/beamme/four_c/element_beam.py
@@ -22,7 +22,6 @@
 """This file implements beam elements for 4C."""
 
 import warnings as _warnings
-from typing import Any as _Any
 
 import numpy as _np
 
@@ -30,6 +29,7 @@ from beamme.core.conf import bme as _bme
 from beamme.core.element_beam import Beam as _Beam
 from beamme.core.element_beam import Beam2 as _Beam2
 from beamme.core.element_beam import generate_beam_class as _generate_beam_class
+from beamme.four_c.element_data import FourCElementData as _FourCElementData
 from beamme.four_c.four_c_types import (
     BeamKirchhoffConstraintType as _BeamKirchhoffConstraintType,
 )
@@ -50,6 +50,11 @@ def get_four_c_reissner_beam(n_nodes: int, is_hermite_centerline: bool) -> type[
         _bme.element_type.beam, n_nodes
     ]
     element_technology = {"HERMITE_CENTERLINE": is_hermite_centerline}
+    data = _FourCElementData(
+        four_c_type=four_c_type,
+        four_c_cell=four_c_cell,
+        element_technology=element_technology,
+    )
 
     if is_hermite_centerline:
         coupling_fix_dict = {"NUMDOF": 9, "ONOFF": [1, 1, 1, 1, 1, 1, 0, 0, 0]}
@@ -64,7 +69,7 @@ def get_four_c_reissner_beam(n_nodes: int, is_hermite_centerline: bool) -> type[
         {
             "element_type": _bme.element_type.beam,
             "beam_type": _BeamType.reissner,
-            "data": {four_c_type: {four_c_cell: element_technology}},
+            "data": data,
             "coupling_fix_dict": coupling_fix_dict,
             "coupling_joint_dict": coupling_joint_dict,
         },
@@ -86,18 +91,23 @@ def get_four_c_kirchhoff_beam(
         )
 
     n_nodes = 3
+
     four_c_type = _INPUT_FILE_MAPPINGS["four_c_type_to_four_c_type"][
         _BeamType.kirchhoff
     ]
     four_c_cell = _INPUT_FILE_MAPPINGS["element_type_and_n_nodes_to_four_c_cell"][
         _bme.element_type.beam, n_nodes
     ]
-
     element_technology = {
         "CONSTRAINT": constraint.name,
         "PARAMETRIZATION": parametrization.name,
         "USE_FAD": is_fad,
     }
+    data = _FourCElementData(
+        four_c_type=four_c_type,
+        four_c_cell=four_c_cell,
+        element_technology=element_technology,
+    )
 
     coupling_fix_dict = {"NUMDOF": 7, "ONOFF": [1, 1, 1, 1, 1, 1, 0]}
     coupling_joint_dict = {"NUMDOF": 7, "ONOFF": [1, 1, 1, 0, 0, 0, 0]}
@@ -109,7 +119,7 @@ def get_four_c_kirchhoff_beam(
             "element_type": _bme.element_type.beam,
             "beam_type": _BeamType.kirchhoff,
             "kirchhoff_parametrization": parametrization,
-            "data": {four_c_type: {four_c_cell: element_technology}},
+            "data": data,
             "coupling_fix_dict": coupling_fix_dict,
             "coupling_joint_dict": coupling_joint_dict,
         },
@@ -121,13 +131,14 @@ class BeamFourCEulerBernoulli(_Beam2):
 
     element_type = _bme.element_type.beam
     beam_type = _BeamType.euler_bernoulli
-    data: dict[str, dict[str, _Any]] = {
-        _INPUT_FILE_MAPPINGS["four_c_type_to_four_c_type"][_BeamType.euler_bernoulli]: {
-            _INPUT_FILE_MAPPINGS["element_type_and_n_nodes_to_four_c_cell"][
-                _bme.element_type.beam, len(_Beam2.nodes_create)
-            ]: {}
-        }
-    }
+    data = _FourCElementData(
+        four_c_type=_INPUT_FILE_MAPPINGS["four_c_type_to_four_c_type"][
+            _BeamType.euler_bernoulli
+        ],
+        four_c_cell=_INPUT_FILE_MAPPINGS["element_type_and_n_nodes_to_four_c_cell"][
+            _bme.element_type.beam, len(_Beam2.nodes_create)
+        ],
+    )
 
     def check(self) -> None:
         """Check that the beam is straight and that the two rotations are the

--- a/src/beamme/four_c/element_data.py
+++ b/src/beamme/four_c/element_data.py
@@ -73,6 +73,8 @@ class FourCElementData:
 
     def __eq__(self, other) -> bool:
         """Check if two 4C element data objects are equal."""
+        if not isinstance(other, FourCElementData):
+            return False
         if self.four_c_cell != other.four_c_cell:
             return False
         if self.four_c_type != other.four_c_type:
@@ -91,7 +93,7 @@ def four_c_element_data_from_legacy_dict(
     input file.
 
     Args:
-        legacy_dict: The legacy element definition in the input file.
+        legacy_dict: The legacy element definition in the input file, will be modified in place.
 
     Returns:
         A tuple containing the 4C element data, the element ID, the connectivity, and the material ID.

--- a/src/beamme/four_c/element_data.py
+++ b/src/beamme/four_c/element_data.py
@@ -21,6 +21,8 @@
 # THE SOFTWARE.
 """Define a data class for 4C element data."""
 
+from dataclasses import dataclass as _dataclass
+from dataclasses import field as _field
 from typing import Any as _Any
 
 import numpy as _np
@@ -31,21 +33,13 @@ from beamme.utils.data_structures import (
 )
 
 
+@_dataclass(eq=False)
 class FourCElementData:
     """Class that contains the data for a 4C element block."""
 
-    def __init__(
-        self,
-        four_c_type: str,
-        four_c_cell: str,
-        element_technology: dict[str, _Any] | None = None,
-    ):
-        """Initialize the 4C element data."""
-        self.four_c_type = four_c_type
-        self.four_c_cell = four_c_cell
-        if element_technology is None:
-            element_technology = {}
-        self.element_technology = element_technology
+    four_c_type: str
+    four_c_cell: str
+    element_technology: dict[str, _Any] = _field(default_factory=dict)
 
     def get_legacy_dict(
         self, element_id, connectivity, element_material_id, additional_element_data

--- a/src/beamme/four_c/element_data.py
+++ b/src/beamme/four_c/element_data.py
@@ -23,6 +23,13 @@
 
 from typing import Any as _Any
 
+import numpy as _np
+from numpy.typing import NDArray as _NDArray
+
+from beamme.utils.data_structures import (
+    compare_nested_dicts_or_lists as _compare_nested_dicts_or_lists,
+)
+
 
 class FourCElementData:
     """Class that contains the data for a 4C element block."""
@@ -63,3 +70,47 @@ class FourCElementData:
                 **(additional_element_data or {}),
             },
         }
+
+    def __eq__(self, other) -> bool:
+        """Check if two 4C element data objects are equal."""
+        if self.four_c_cell != other.four_c_cell:
+            return False
+        if self.four_c_type != other.four_c_type:
+            return False
+        if not _compare_nested_dicts_or_lists(
+            self.element_technology, other.element_technology
+        ):
+            return False
+        return True
+
+
+def four_c_element_data_from_legacy_dict(
+    legacy_dict: dict,
+) -> tuple[FourCElementData, int, _NDArray, int]:
+    """Extract the 4C element data from a legacy element definition in the
+    input file.
+
+    Args:
+        legacy_dict: The legacy element definition in the input file.
+
+    Returns:
+        A tuple containing the 4C element data, the element ID, the connectivity, and the material ID.
+    """
+
+    element_id = legacy_dict["id"]
+    connectivity = _np.array(legacy_dict["cell"]["connectivity"], dtype=int) - 1
+    four_c_cell = legacy_dict["cell"]["type"]
+
+    # Since we directly store `legacy_dict["data"]` as the element technology data,
+    # the material ID and four_c_type have to be removed from the `legacy_dict["data"]`
+    # dictionary, thus the `pop`.
+    material_id = legacy_dict["data"].pop("MAT", -1)
+    four_c_type = legacy_dict["data"].pop("type")
+
+    data = FourCElementData(
+        four_c_type=four_c_type,
+        four_c_cell=four_c_cell,
+        element_technology=legacy_dict["data"],
+    )
+
+    return data, element_id, connectivity, material_id

--- a/src/beamme/four_c/element_data.py
+++ b/src/beamme/four_c/element_data.py
@@ -1,0 +1,65 @@
+# The MIT License (MIT)
+#
+# Copyright (c) 2018-2026 BeamMe Authors
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+"""Define a data class for 4C element data."""
+
+from typing import Any as _Any
+
+
+class FourCElementData:
+    """Class that contains the data for a 4C element block."""
+
+    def __init__(
+        self,
+        four_c_type: str,
+        four_c_cell: str,
+        element_technology: dict[str, _Any] | None = None,
+    ):
+        """Initialize the 4C element data."""
+        self.four_c_type = four_c_type
+        self.four_c_cell = four_c_cell
+        if element_technology is None:
+            element_technology = {}
+        self.element_technology = element_technology
+
+    def get_legacy_dict(
+        self, element_id, connectivity, element_material_id, additional_element_data
+    ) -> dict:
+        """Return the dictionary to write this element data to a legacy element
+        definition in the input file."""
+
+        return {
+            "id": element_id + 1,
+            "cell": {
+                "type": self.four_c_cell,
+                "connectivity": connectivity + 1,
+            },
+            "data": {
+                "type": self.four_c_type,
+                **(
+                    {"MAT": element_material_id + 1}
+                    if element_material_id != -1
+                    else {}
+                ),
+                **self.element_technology,
+                **(additional_element_data or {}),
+            },
+        }

--- a/src/beamme/four_c/element_solid.py
+++ b/src/beamme/four_c/element_solid.py
@@ -34,6 +34,7 @@ from beamme.core.element_volume import VolumeTET10 as _VolumeTET10
 from beamme.core.element_volume import VolumeWEDGE6 as _VolumeWEDGE6
 from beamme.core.nurbs_patch import NURBSSurface as _NURBSSurface
 from beamme.core.nurbs_patch import NURBSVolume as _NURBSVolume
+from beamme.four_c.element_data import FourCElementData as _FourCElementData
 from beamme.four_c.input_file_mappings import (
     INPUT_FILE_MAPPINGS as _INPUT_FILE_MAPPINGS,
 )
@@ -104,11 +105,13 @@ def get_four_c_solid(
     four_c_cell = _INPUT_FILE_MAPPINGS["element_type_and_n_nodes_to_four_c_cell"][
         solid_type, n_nodes
     ]
+    data = _FourCElementData(
+        four_c_type=four_c_type,
+        four_c_cell=four_c_cell,
+        element_technology=element_technology,
+    )
     return type(
         "FourCSolidElementType",
         (base_type,),
-        {
-            "element_type": solid_type,
-            "data": {four_c_type: {four_c_cell: element_technology}},
-        },
+        {"element_type": solid_type, "data": data},
     )

--- a/src/beamme/four_c/input_file.py
+++ b/src/beamme/four_c/input_file.py
@@ -35,6 +35,7 @@ from fourcipp.utils.not_set import NOT_SET as _NOT_SET
 from beamme.core.conf import INPUT_FILE_HEADER as _INPUT_FILE_HEADER
 from beamme.core.mesh import Mesh as _Mesh
 from beamme.core.mesh_representation import MeshRepresentation as _MeshRepresentation
+from beamme.four_c.element_data import FourCElementData as _FourCElementData
 from beamme.four_c.input_file_dump_functions import (
     dump_mesh_representation_to_input_file_legacy as _dump_mesh_representation_to_input_file_legacy,
 )
@@ -66,7 +67,7 @@ class InputFile:
 
         # Mesh representation for this input file.
         self.mesh_representation = _MeshRepresentation()
-        self.element_type_id_to_data: dict[_Any, _Any] = {}
+        self.element_type_id_to_data: dict[_Any, _FourCElementData] = {}
 
     def __contains__(self, key: str) -> bool:
         """Contains function.

--- a/src/beamme/four_c/input_file_dump_functions.py
+++ b/src/beamme/four_c/input_file_dump_functions.py
@@ -21,7 +21,6 @@
 # THE SOFTWARE.
 """This file defines functions to dump mesh items for 4C."""
 
-import copy as _copy
 from collections import defaultdict as _defaultdict
 from typing import Any as _Any
 from typing import KeysView as _KeysView
@@ -47,6 +46,7 @@ from beamme.core.mesh_representation import (
 )
 from beamme.core.nurbs_patch import NURBSPatch as _NURBSPatch
 from beamme.core.rotation import Rotation as _Rotation
+from beamme.four_c.element_data import FourCElementData as _FourCElementData
 from beamme.four_c.four_c_types import (
     BeamKirchhoffParametrizationType as _BeamKirchhoffParametrizationType,
 )
@@ -323,7 +323,7 @@ def dump_mesh_to_input_file(input_file, mesh: _Mesh) -> None:
 def dump_mesh_representation_to_input_file_legacy(
     fourc_input: _FourCInput,
     mesh_representation: _MeshRepresentation,
-    element_type_id_to_data: dict[int, dict],
+    element_type_id_to_data: dict[int, _FourCElementData],
 ) -> None:
     """Dump the information contained in the mesh representation to the 4C
     input file via FourCIPP, in legacy format.
@@ -398,32 +398,16 @@ def dump_mesh_representation_to_input_file_legacy(
     ):
         element_type_data = element_type_id_to_data[element_type_id]
 
-        if len(element_type_data) == 1:
-            four_c_type, four_c_cell_dict = next(iter(element_type_data.items()))
-        else:
-            raise ValueError("Expected exactly one entry in type dictionary")
-        if len(four_c_cell_dict) == 1:
-            four_c_cell, four_c_data = next(iter(four_c_cell_dict.items()))
-        else:
-            raise ValueError("Expected exactly one entry in cell dictionary")
-
         node_ordering = _INPUT_FILE_MAPPINGS[
             "four_c_cell_to_connectivity_mapping_from_vtk"
-        ].get(four_c_cell, None)
+        ].get(element_type_data.four_c_cell, None)
         if node_ordering is not None:
             connectivity = connectivity[node_ordering]
 
-        if element_material_id == -1:
-            material_dict = {}
-        else:
-            material_dict = {"MAT": element_material_id + 1}
-
+        additional_element_data = None
         if _INPUT_FILE_MAPPINGS["four_c_type_to_requires_triads"].get(
-            four_c_type, False
+            element_type_data.four_c_type, False
         ):
-            # We modify the dict to add the rotation vectors, thus we create a
-            # deep copy here to avoid modifying the original data structure.
-            four_c_data = _copy.deepcopy(four_c_data)
             # The numpy quaternion package can return rotation vectors outside
             # the range of -pi to pi, which can cause issues in testing comparisons.
             # To avoid this, we convert the rotations to BeamMe internal rotations
@@ -433,7 +417,7 @@ def dump_mesh_representation_to_input_file_legacy(
             # be preferred when performance is of importance.
             if "rotation_vector" not in mesh_representation.point_data:
                 raise KeyError(
-                    f"Rotation vectors are required for type {four_c_type}, but "
+                    f"Rotation vectors are required for type {element_type_data.four_c_type}, but "
                     "no rotation vectors found in the mesh representation!"
                 )
             rotations = [
@@ -442,19 +426,19 @@ def dump_mesh_representation_to_input_file_legacy(
                     "rotation_vector"
                 ][connectivity]
             ]
-            four_c_data["TRIADS"] = _np.array(
-                [rotation.get_rotation_vector() for rotation in rotations]
-            ).ravel()
+            additional_element_data = {
+                "TRIADS": _np.array(
+                    [rotation.get_rotation_vector() for rotation in rotations]
+                ).ravel()
+            }
 
         element_list.append(
-            {
-                "id": start_index_elements + i_element + 1,
-                "cell": {
-                    "type": four_c_cell,
-                    "connectivity": start_index_nodes + connectivity + 1,
-                },
-                "data": {"type": four_c_type, **material_dict, **four_c_data},
-            }
+            element_type_data.get_legacy_dict(
+                element_id=start_index_elements + i_element,
+                connectivity=start_index_nodes + connectivity,
+                element_material_id=element_material_id,
+                additional_element_data=additional_element_data,
+            )
         )
     _dump("STRUCTURE ELEMENTS", element_list)
 

--- a/src/beamme/four_c/model_importer.py
+++ b/src/beamme/four_c/model_importer.py
@@ -45,15 +45,16 @@ from beamme.core.mesh_representation import (
     string_to_geometry_set_info as _string_to_geometry_set_info,
 )
 from beamme.core.node import Node as _Node
+from beamme.four_c.element_data import FourCElementData as _FourCElementData
+from beamme.four_c.element_data import (
+    four_c_element_data_from_legacy_dict as _four_c_element_data_from_legacy_dict,
+)
 from beamme.four_c.element_solid import get_four_c_solid as _get_four_c_solid
 from beamme.four_c.input_file import InputFile as _InputFile
 from beamme.four_c.input_file_mappings import (
     INPUT_FILE_MAPPINGS as _INPUT_FILE_MAPPINGS,
 )
 from beamme.four_c.material import MaterialSolid as _MaterialSolid
-from beamme.utils.data_structures import (
-    compare_nested_dicts_or_lists as _compare_nested_dicts_or_lists,
-)
 from beamme.utils.environment import cubitpy_is_available as _cubitpy_is_available
 
 if _cubitpy_is_available():
@@ -72,9 +73,9 @@ class UniqueDataTracker:
     """
 
     def __init__(self) -> None:
-        self.unique_id_to_data: dict[int, dict] = {}
+        self.unique_id_to_data: dict[int, _FourCElementData] = {}
 
-    def get_unique_id(self, data: dict) -> int:
+    def get_unique_id(self, data: _FourCElementData) -> int:
         """Get the unique ID for the given data. If the data has not been seen
         before, a new ID will be assigned to it.
 
@@ -85,7 +86,7 @@ class UniqueDataTracker:
             The unique ID for the given data.
         """
         for unique_id, seen_data in self.unique_id_to_data.items():
-            if _compare_nested_dicts_or_lists(data, seen_data):
+            if data == seen_data:
                 return unique_id
 
         # If we reach this point, the data has not been seen before. We assign a new ID to it.
@@ -179,7 +180,7 @@ def _extract_mesh_from_input_file(input_file: _InputFile) -> tuple[_InputFile, _
 
 def _extract_mesh_representation(
     input_file: _InputFile,
-) -> tuple[_MeshRepresentation, dict[int, dict], dict[int, int]]:
+) -> tuple[_MeshRepresentation, dict[int, _FourCElementData], dict[int, int]]:
     """Extract the mesh representation from mesh data directly contained in the
     input file.
 
@@ -228,25 +229,15 @@ def _extract_mesh_representation(
     cell_element_type_ids = _np.full(n_elements, -1)
     cell_material_ids = _np.full(n_elements, -1)
     for i_element, input_element in enumerate(elements):
-        # At this point `input_element` contains the full element data. We can not
-        # compare this directly with the other block data dictionaries, we first
-        # need to extract connectivity and cell ID.
-        element_id = input_element.pop("id")
-        connectivity = (
-            _np.array(input_element["cell"].pop("connectivity"), dtype=int) - 1
+        four_c_element_data, element_id, connectivity, material_id = (
+            _four_c_element_data_from_legacy_dict(input_element)
         )
-        material_id = input_element["data"].pop("MAT", -1)
-
-        # Get the cell type, but keep it in the input element data
-        four_c_cell_type = input_element["cell"]["type"]
-
-        # Get the id of the current element
-        element_type_id = element_type_tracker.get_unique_id(input_element)
+        element_type_id = element_type_tracker.get_unique_id(four_c_element_data)
 
         # Check if connectivity has to be reordered
         reorder_indices = _INPUT_FILE_MAPPINGS[
             "four_c_cell_to_vtk_connectivity_mapping"
-        ].get(four_c_cell_type, None)
+        ].get(four_c_element_data.four_c_cell, None)
         if reorder_indices is not None:
             connectivity = connectivity[reorder_indices]
 
@@ -254,11 +245,11 @@ def _extract_mesh_representation(
 
         try:
             vtk_cell_type = _INPUT_FILE_MAPPINGS["four_c_cell_to_vtk_cell_type"][
-                four_c_cell_type
+                four_c_element_data.four_c_cell
             ]
         except KeyError:
             raise ValueError(
-                f"Unknown cell type `{four_c_cell_type}` for element {element_id}."
+                f"Unknown cell type `{four_c_element_data.four_c_cell}` for element {element_id}."
             )
 
         cell_types[i_element] = vtk_cell_type
@@ -375,21 +366,18 @@ def _create_mesh_from_mesh_representation(
         element_type_id,
         element_data,
     ) in element_type_id_to_data.items():
-        # We can modify this in place here, as `element_type_id_to_data` is not used anymore after this function.
-        four_c_type = element_data["data"].pop("type")
-        four_c_cell_type = element_data["cell"]["type"]
         element_type, n_nodes = _INPUT_FILE_MAPPINGS[
             "four_c_cell_to_element_type_and_n_nodes"
-        ][four_c_cell_type]
+        ][element_data.four_c_cell]
         if not element_type == _bme.element_type.solid:
             raise ValueError(
                 f"Mesh conversion for element type {element_type} is not implemented!"
             )
         element_type_id_to_element_type[element_type_id] = _get_four_c_solid(
             element_type,
-            four_c_type,
+            element_data.four_c_type,
             n_nodes=n_nodes,
-            element_technology=element_data["data"],
+            element_technology=element_data.element_technology,
         )
 
     # loop over the elements and create the mesh elements with the correct type, connectivity and material.

--- a/src/beamme/four_c/solid_shell_thickness_direction.py
+++ b/src/beamme/four_c/solid_shell_thickness_direction.py
@@ -197,12 +197,15 @@ def set_solid_shell_thickness_direction(
         raise ValueError("Expected a non empty element list")
 
     for element in elements:
+        four_c_data = getattr(type(element), "data", None)
+        if four_c_data is None:
+            raise ValueError(
+                "Expected element type to have a data attribute with the 4C element data!"
+            )
         is_hex8_solid_shell = (
-            getattr(type(element), "data", {})
-            .get("SOLID", {})
-            .get("HEX8", {})
-            .get("TECH", "")
-            == "shell_eas_ans"
+            four_c_data.four_c_type == "SOLID"
+            and four_c_data.four_c_cell == "HEX8"
+            and four_c_data.element_technology.get("TECH", "") == "shell_eas_ans"
         )
         if is_hex8_solid_shell:
             # Get the element center and the Jacobian at the center


### PR DESCRIPTION
In 4C we use different data structures for elements in legacy format or external mesh format. This makes a direct unified output cumbersome. This PR adds a class `FourCElementData` that can handle both cases.