### PR TITLE
Fix material modularisation

### DIFF
--- a/src/beamme/core/mesh.py
+++ b/src/beamme/core/mesh.py
@@ -62,9 +62,6 @@ from beamme.core.rotation import Rotation as _Rotation
 from beamme.core.rotation import add_rotations as _add_rotations
 from beamme.core.rotation import rotate_coordinates as _rotate_coordinates
 from beamme.core.vtk_writer import VTKWriter as _VTKWriter
-from beamme.four_c.material import (
-    get_all_contained_materials as _get_all_contained_materials,
-)
 from beamme.geometric_search.find_close_points import (
     find_close_points as _find_close_points,
 )
@@ -719,36 +716,31 @@ class Mesh:
         return _get_nodes_by_function(self.nodes, *args, **kwargs)
 
     def get_mesh_representation(
-        self,
+        self, material_to_i_global: dict[_Material, int]
     ) -> tuple[
         _MeshRepresentation,
         dict[int, _Any],
         dict[_GeometrySetBase, int],
-        dict[_Material, int],
         dict[_NURBSPatch, int],
     ]:
         """Create a mesh representation for this mesh.
 
-        This function does not alter the mesh object. It assigns internal IDs to the mesh object and returns mappings between the objects and the IDs.
+        This function does not alter the mesh object. It assigns internal IDs to the
+        mesh object and returns mappings between the objects and the IDs.
+
+        Args:
+            material_to_i_global: A dictionary that maps materials to their global
+                index in the mesh representation.
 
         Returns:
             mesh_representation: `MeshRepresentation` object for this mesh.
-            element_type_id_to_data: A dictionary that maps the element type id to the data of the element type.
-            geometry_sets_to_i_global: A dictionary that maps geometry sets to their global index in the mesh representation.
-            material_to_i_global: A dictionary that maps materials to their global index in the mesh representation.
-            nurbs_patch_to_i_global: A dictionary that maps each NURBS patch to the global ID of that patch.
+            element_type_id_to_data: A dictionary that maps the element type id to the
+                data of the element type.
+            geometry_sets_to_i_global: A dictionary that maps geometry sets to their
+                global index in the mesh representation.
+            nurbs_patch_to_i_global: A dictionary that maps each NURBS patch to the
+                global ID of that patch.
         """
-
-        # Get a list of all materials in the mesh, including nested sub-materials
-        # and create he global ID mapping.
-        all_materials = [
-            material
-            for mesh_material in self.materials
-            for material in _get_all_contained_materials(mesh_material)
-        ]
-        material_to_i_global: dict[_Material, int] = {}
-        for material in all_materials:
-            material_to_i_global[material] = len(material_to_i_global)
 
         # Get the global id mappings for geometry sets.
         mesh_sets = self.get_unique_geometry_sets()
@@ -934,7 +926,6 @@ class Mesh:
             mesh_representation,
             element_type_id_to_data,
             geometry_sets_to_i_global,
-            material_to_i_global,
             nurbs_patch_to_i_global,
         )
 

--- a/src/beamme/four_c/element_data.py
+++ b/src/beamme/four_c/element_data.py
@@ -100,7 +100,7 @@ def four_c_element_data_from_legacy_dict(
     # Since we directly store `legacy_dict["data"]` as the element technology data,
     # the material ID and four_c_type have to be removed from the `legacy_dict["data"]`
     # dictionary, thus the `pop`.
-    material_id = legacy_dict["data"].pop("MAT", -1)
+    material_id = legacy_dict["data"].pop("MAT", 0) - 1
     four_c_type = legacy_dict["data"].pop("type")
 
     data = FourCElementData(

--- a/src/beamme/four_c/input_file_dump_functions.py
+++ b/src/beamme/four_c/input_file_dump_functions.py
@@ -54,6 +54,9 @@ from beamme.four_c.four_c_types import BeamType as _BeamType
 from beamme.four_c.input_file_mappings import (
     INPUT_FILE_MAPPINGS as _INPUT_FILE_MAPPINGS,
 )
+from beamme.four_c.material import (
+    get_material_to_i_global_mapping as _get_material_to_i_global_mapping,
+)
 
 
 def dump_function(function: _Function, i_global: int) -> dict[str, _Any]:
@@ -205,14 +208,16 @@ def dump_mesh_to_input_file(input_file, mesh: _Mesh) -> None:
         default=0,
     )
 
+    # Get material to global index mapping for the materials in the mesh.
+    material_to_i_global = _get_material_to_i_global_mapping(mesh.materials)
+
     # Get the mesh representation for the mesh.
     (
         mesh_representation,
         mesh_element_type_id_to_data,
         geometry_sets_to_i_global,
-        material_to_i_global,
         nurbs_patch_to_i_global,
-    ) = mesh.get_mesh_representation()
+    ) = mesh.get_mesh_representation(material_to_i_global)
     mesh_representation.offset_indices(
         element_type_id_offset=start_index_element_types,
         material_offset=start_index_materials,

--- a/src/beamme/four_c/material.py
+++ b/src/beamme/four_c/material.py
@@ -28,7 +28,7 @@ from beamme.core.material import MaterialBeamBase as _MaterialBeamBase
 from beamme.core.material import MaterialSolidBase as _MaterialSolidBase
 
 
-def get_all_contained_materials(
+def get_material_and_all_contained_sub_materials(
     material: _Material, _visited_materials: set[int] | None = None
 ) -> list[_Material]:
     """Recursively collect all materials contained within a material, including
@@ -64,10 +64,36 @@ def get_all_contained_materials(
         for item in material.data["MATIDS"]:
             if isinstance(item, _Material):
                 contained_materials.extend(
-                    get_all_contained_materials(item, _visited_materials)
+                    get_material_and_all_contained_sub_materials(
+                        item, _visited_materials
+                    )
                 )
 
     return contained_materials
+
+
+def get_material_to_i_global_mapping(
+    materials: list[_Material],
+) -> dict[_Material, int]:
+    """Get a mapping of all materials in the mesh to their global IDs.
+
+    Args:
+        materials: A list of all materials in the mesh.
+
+    Returns:
+        A dictionary mapping each material to its global ID. This also includes
+        sub-materials contained within other materials.
+    """
+    all_materials = [
+        material
+        for mesh_material in materials
+        for material in get_material_and_all_contained_sub_materials(mesh_material)
+    ]
+    material_to_i_global: dict[_Material, int] = {}
+    for material in all_materials:
+        if material not in material_to_i_global:
+            material_to_i_global[material] = len(material_to_i_global)
+    return material_to_i_global
 
 
 class MaterialReissner(_MaterialBeamBase):

--- a/src/beamme/four_c/model_importer.py
+++ b/src/beamme/four_c/model_importer.py
@@ -466,7 +466,7 @@ def _extract_materials_from_input_file(
     material_id_map_all = {}
 
     for mat in input_file.pop("MATERIALS", []):
-        mat_id = mat.pop("MAT")
+        mat_id = mat.pop("MAT") - 1
         if len(mat) != 1:
             raise ValueError(
                 f"Could not convert the material data `{mat}` to a BeamMe material!"
@@ -477,18 +477,19 @@ def _extract_materials_from_input_file(
 
     nested_materials = set()
     for material in material_id_map_all.values():
-        # Loop over each material and link nested materials. Also, mark nested materials
-        # as they will not be added to the mesh.
-        material_ids = material.data.get("MATIDS", [])
-        for i_sub_material, material_id in enumerate(material_ids):
+        # Replace the integer IDs in the "MATIDS" list of the material with the actual
+        # material objects.
+        sub_materials = material.data.get("MATIDS", [])
+        sub_material_ids = _np.array(sub_materials) - 1
+        for i_sub_material, sub_material_id in enumerate(sub_material_ids):
             try:
-                material_ids[i_sub_material] = material_id_map_all[material_id]
+                sub_materials[i_sub_material] = material_id_map_all[sub_material_id]
             except KeyError as key_exception:
                 raise KeyError(
-                    f"Material ID {material_id} not in material_id_map_all (available "
+                    f"Material ID {sub_material_id} not in material_id_map_all (available "
                     f"IDs: {list(material_id_map_all.keys())})."
                 ) from key_exception
-            nested_materials.add(material_id)
+            nested_materials.add(sub_material_id)
 
     # Get a map of all non-nested materials. We assume that only those are used as
     # materials for elements. Also, add the non-nested materials to the mesh.

--- a/tests/beamme/four_c/test_beamme_four_c_material.py
+++ b/tests/beamme/four_c/test_beamme_four_c_material.py
@@ -23,13 +23,15 @@
 
 import pytest
 
+from beamme.core.mesh import Mesh
 from beamme.four_c.material import (
     MaterialKirchhoff,
     MaterialReissner,
     MaterialReissnerElastoplastic,
     MaterialSolid,
     MaterialStVenantKirchhoff,
-    get_all_contained_materials,
+    get_material_and_all_contained_sub_materials,
+    get_material_to_i_global_mapping,
 )
 
 
@@ -261,7 +263,7 @@ def test_beamme_four_c_material_sub_materials():
     material = MaterialSolid(
         material_string="mat", data={"MATIDS": [material_1, material_2, material_3]}
     )
-    sub_materials = get_all_contained_materials(material)
+    sub_materials = get_material_and_all_contained_sub_materials(material)
 
     sub_materials_reference = [
         material,
@@ -292,4 +294,28 @@ def test_beamme_four_c_material_sub_materials_circular_loop():
 
     # Check that the circular reference is detected
     with pytest.raises(ValueError, match="Circular material reference detected!"):
-        get_all_contained_materials(material_1)
+        get_material_and_all_contained_sub_materials(material_1)
+
+
+def test_beamme_four_c_material_sub_materials_indexing():
+    """Check the error for incorrectly added sub-materials."""
+
+    mesh = Mesh()
+    material_sub = MaterialSolid(
+        material_string="ELAST_CoupSVK", data={"YOUNG": 1.0, "NUE": 0.0}
+    )
+    mesh.add(material_sub)
+    material = MaterialSolid(
+        material_string="MAT_ElastHyper",
+        data={
+            "NUMMAT": 1,
+            "MATIDS": [material_sub],
+            "DENS": 1.0,
+        },
+    )
+    mesh.add(material)
+
+    material_to_i_global = get_material_to_i_global_mapping(mesh.materials)
+    assert len(material_to_i_global) == 2
+    assert material_to_i_global[material_sub] == 0
+    assert material_to_i_global[material] == 1

--- a/tests/integration/test_integration_four_c_model_importer.py
+++ b/tests/integration/test_integration_four_c_model_importer.py
@@ -147,7 +147,7 @@ def test_integration_four_c_model_importer_import_nested_materials_error():
     with pytest.raises(
         KeyError,
         match=re.escape(
-            "Material ID 3 not in material_id_map_all (available IDs: [1, 2])."
+            "Material ID 2 not in material_id_map_all (available IDs: [0, 1])."
         ),
     ):
         _extract_materials_from_input_file(input_file)


### PR DESCRIPTION
With #633 we use `MeshRepresentation` as the intermediate data structure between a mesh and an input file.

The changes from #633 import `from beamme.four_c.material` in `core/mesh.py`, which is not ideal with respect to modularisation. This PR fixes that by restructuring where the material ID lookup map is created.

Also the ID handling of materials is changed, now the BeamMe internal material IDs are index-0 based.