### PR TITLE
Improve naming of CubitPy / Coreform in testing

### DIFF
--- a/.github/workflows/testing_protected.yml
+++ b/.github/workflows/testing_protected.yml
@@ -57,7 +57,7 @@ jobs:
       - name: Run the test suite and upload results on failure
         uses: ./.github/actions/run_tests
         with:
-          additional-pytest-flags: "--4C --ArborX --CubitPy --check-for-unused-reference-files --cov-fail-under=93"
+          additional-pytest-flags: "--4C --ArborX --Coreform --check-for-unused-reference-files --cov-fail-under=93"
           cubit-root: ${{ steps.cubit.outputs.cubit_root }}
       - name: Free cubit license
         if: ${{ always() }}
@@ -107,7 +107,7 @@ jobs:
       - name: Run the test suite and upload results on failure
         uses: ./.github/actions/run_tests
         with:
-          additional-pytest-flags: "--performance-tests --CubitPy --exclude-standard-tests -s --no-cov"
+          additional-pytest-flags: "--performance-tests --Coreform --exclude-standard-tests -s --no-cov"
           cubit-root: ${{ steps.cubit.outputs.cubit_root }}
       - name: Free cubit license
         if: ${{ always() }}

--- a/README.md
+++ b/README.md
@@ -365,17 +365,17 @@ BeamMe provides a flexible testing system where additional tests can be enabled 
  - `--exclude-standard-tests`: Disables the default test suite
  - `--4C`: Runs tests related to 4C integration
  - `--ArborX`: Enables tests for ArborX-related functionality
- - `--CubitPy`: Runs tests for CubitPy integration
+ - `--Coreform`: Runs tests that require Coreform Cubit
  - `--performance-tests`: Includes performance tests
 
-These flags can be combined arbitrarily; for example, to run the 4C, CubitPy, and ArborX tests but exclude the default test suite, use:
+These flags can be combined arbitrarily; for example, to run the 4C, Coreform Cubit, and ArborX tests but exclude the default test suite, use:
 ```bash
 # 4C Tests require a path to a 4C executable
 export BEAMME_FOUR_C_EXE=<path_to_4C>
-# CubitPy Tests require a path to a Cubit/Coreform installation
+# Coreform Tests require a path to a Coreform Cubit installation
 export CUBIT_ROOT=<path_to_Cubit_or_Coreform>
 
-pytest --4C --ArborX --CubitPy --exclude-standard-tests
+pytest --4C --ArborX --Coreform --exclude-standard-tests
 ```
 
 ### Cython geometric search

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -68,6 +68,6 @@ addopts = "-p pytest_cov --cov-report=term --cov-report=html --cov-report=xml --
 markers = [
   "fourc: tests in combination with 4C",
   "arborx: tests in combination with ArborX",
-  "cubitpy: tests in combination with CubitPy",
+  "coreform: tests in combination with Coreform Cubit",
   "performance: performance tests"
 ]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -65,10 +65,10 @@ def pytest_addoption(parser: Parser) -> None:
     )
 
     parser.addoption(
-        "--CubitPy",
+        "--Coreform",
         action="store_true",
         default=False,
-        help="Execute standard and CubitPy based tests.",
+        help="Execute standard and Coreform based tests.",
     )
 
     parser.addoption(
@@ -129,7 +129,7 @@ def pytest_collection_modifyitems(config: Config, items: list) -> None:
         `pytest`: Execute standard tests with no markers
         `pytest --4C`: Execute standard tests and tests with the `fourc` marker
         `pytest --ArborX`: Execute standard tests and tests with the `arborx` marker
-        `pytest --CubitPy`: Execute standard tests and tests with the `cubitpy` marker
+        `pytest --Coreform`: Execute standard tests and tests with the `coreform` marker
         `pytest --performance-tests`: Execute standard tests and tests with the `performance` marker
         `pytest --exclude-standard-tests`: Execute tests with any other marker and exclude the standard unmarked tests
         `pytest --check-for-unused-reference-files`: Check for unused reference files in the reference file directory
@@ -142,8 +142,8 @@ def pytest_collection_modifyitems(config: Config, items: list) -> None:
     # Get all active markers for this pytest run
     active_markers = set()
     for flag, marker in zip(
-        ["--4C", "--ArborX", "--CubitPy", "--performance-tests"],
-        ["fourc", "arborx", "cubitpy", "performance"],
+        ["--4C", "--ArborX", "--Coreform", "--performance-tests"],
+        ["fourc", "arborx", "coreform", "performance"],
     ):
         if config.getoption(flag):
             active_markers.add(marker)
@@ -154,7 +154,7 @@ def pytest_collection_modifyitems(config: Config, items: list) -> None:
     for item in items:
         _check_naming_convention(item)
 
-        # Get all set markers for current test (e.g. `4C`, `ArborX`, `CubitPy`, ...)
+        # Get all set markers for current test (e.g. `4C`, `ArborX`, `Coreform`, ...)
         # We don't care about the "parametrize" marker here
         markers = set(
             marker.name

--- a/tests/integration/test_integration_four_c_model_importer.py
+++ b/tests/integration/test_integration_four_c_model_importer.py
@@ -38,7 +38,7 @@ from tests.create_test_models import create_multiple_solid_bricks, create_tube_c
 
 
 @pytest.mark.parametrize("full_import", (False, True))
-@pytest.mark.cubitpy
+@pytest.mark.coreform
 def test_integration_four_c_model_importer_import_cubitpy_model(
     full_import, assert_results_close, get_corresponding_reference_file_path
 ):
@@ -60,7 +60,7 @@ def test_integration_four_c_model_importer_import_cubitpy_model(
 
 
 @pytest.mark.parametrize("full_import", (False, True))
-@pytest.mark.cubitpy
+@pytest.mark.coreform
 def test_integration_four_c_model_importer_solid_element_types_from_cubitpy(
     full_import, assert_results_close, get_corresponding_reference_file_path
 ):

--- a/tests/other/test_other_create_cubit_input_files.py
+++ b/tests/other/test_other_create_cubit_input_files.py
@@ -33,7 +33,7 @@ from tests.create_test_models import (
 )
 
 
-@pytest.mark.cubitpy
+@pytest.mark.coreform
 def test_other_create_cubit_input_files_tube(
     tmp_path,
     get_corresponding_reference_file_path,
@@ -46,7 +46,7 @@ def test_other_create_cubit_input_files_tube(
     assert_results_close(result_path, get_corresponding_reference_file_path())
 
 
-@pytest.mark.cubitpy
+@pytest.mark.coreform
 def test_other_create_cubit_input_files_block(
     tmp_path,
     get_corresponding_reference_file_path,
@@ -59,7 +59,7 @@ def test_other_create_cubit_input_files_block(
     assert_results_close(result_path, get_corresponding_reference_file_path())
 
 
-@pytest.mark.cubitpy
+@pytest.mark.coreform
 def test_other_create_cubit_input_files_solid_shell(
     tmp_path,
     get_corresponding_reference_file_path,
@@ -81,7 +81,7 @@ def test_other_create_cubit_input_files_solid_shell(
     assert_results_close(result_path_dome, reference_path_dome)
 
 
-@pytest.mark.cubitpy
+@pytest.mark.coreform
 def test_other_create_cubit_input_files_single_solid_element_brick(
     tmp_path,
     get_corresponding_reference_file_path,
@@ -99,7 +99,7 @@ def test_other_create_cubit_input_files_single_solid_element_brick(
     assert_results_close(result_path, reference_file)
 
 
-@pytest.mark.cubitpy
+@pytest.mark.coreform
 def test_other_create_cubit_input_files_solid_brick(
     tmp_path,
     get_corresponding_reference_file_path,
@@ -115,7 +115,7 @@ def test_other_create_cubit_input_files_solid_brick(
     assert_results_close(result_path, reference_file)
 
 
-@pytest.mark.cubitpy
+@pytest.mark.coreform
 def test_other_create_cubit_input_files_multiple_solid_bricks(
     tmp_path, get_corresponding_reference_file_path, assert_results_close
 ):

--- a/tests/other/test_other_logo.py
+++ b/tests/other/test_other_logo.py
@@ -31,7 +31,7 @@ sys.path.insert(0, str(Path(__file__).parent.parent.parent / "utils"))
 from logo import create_beamme_logo
 
 
-@pytest.mark.cubitpy
+@pytest.mark.coreform
 def test_other_logo(tmp_path):
     """Simply test that the logo function does not throw an error."""
     create_beamme_logo(tmp_path, create_cubit=True)

--- a/tests/performance/test_performance_beamme.py
+++ b/tests/performance/test_performance_beamme.py
@@ -198,7 +198,7 @@ def medium_solid_block(shared_tmp_path, evaluate_execution_time):
     return input_file_path
 
 
-@pytest.mark.cubitpy
+@pytest.mark.coreform
 @pytest.mark.performance
 def test_performance_beamme_cubitpy_create_solid(medium_solid_block):
     """Test the performance of creating a solid block using CubitPy.
@@ -234,7 +234,7 @@ def large_solid_block(evaluate_execution_time, medium_solid_block, shared_tmp_pa
     )
 
 
-@pytest.mark.cubitpy
+@pytest.mark.coreform
 @pytest.mark.performance
 def test_performance_beamme_double_solid_block(large_solid_block):
     """Test the performance of doubling a solid block from an input file.
@@ -245,7 +245,7 @@ def test_performance_beamme_double_solid_block(large_solid_block):
     pass
 
 
-@pytest.mark.cubitpy
+@pytest.mark.coreform
 @pytest.mark.parametrize(
     ("log_name", "full_import", "expected_time"),
     [


### PR DESCRIPTION
This is a perquisite for #651.

We need to split up the dependency on CubitPy and the dependency on an actual CoreformCubit installation for testing. This is done in this PR, where the test marker `@pytest.mark.cubitpy` is replaced with `@pytest.mark.coreform`.

Tests will fail since this is still run with the test suite on `main`, but they should pass once they are merged, as I only did a global replace and adapted the readme.