### PR TITLE
Use CubitPy config file during testing

### DIFF
--- a/.github/actions/cubitpy_config/action.yml
+++ b/.github/actions/cubitpy_config/action.yml
@@ -1,0 +1,25 @@
+name: cubitpy_config
+description: Setup a CubitPy config file
+inputs:
+  cubit-root:
+    description: Path to the cubit installation
+    required: true
+outputs:
+  cubitpy_config_path:
+    description: "Path to the CubitPy config file"
+    value: ${{ steps.cubitpy_config.outputs.cubitpy_config_path }}
+runs:
+  using: composite
+  steps:
+    - name: Create the CubitPy config file
+      id: cubitpy_config
+      shell: bash
+      run: |
+        CUBITPY_CONFIG_PATH="${RUNNER_TEMP:-$HOME}/cubitpy_config_local.yml"
+        cat > $CUBITPY_CONFIG_PATH <<EOF
+        cubitpy_mode: "local"
+        local_config:
+          cubit_path: "${{ inputs.cubit-root }}"
+        EOF
+        cat "$CUBITPY_CONFIG_PATH"
+        echo "cubitpy_config_path=$CUBITPY_CONFIG_PATH" >> "$GITHUB_OUTPUT"

--- a/.github/actions/cubitpy_config/action.yml
+++ b/.github/actions/cubitpy_config/action.yml
@@ -12,7 +12,6 @@ runs:
   using: composite
   steps:
     - name: Create the CubitPy config file
-      id: cubitpy_config
       shell: bash
       run: |
         CUBITPY_CONFIG_PATH="${RUNNER_TEMP:-$HOME}/cubitpy_config_local.yml"

--- a/.github/actions/run_tests/action.yml
+++ b/.github/actions/run_tests/action.yml
@@ -5,8 +5,8 @@ inputs:
     description: Additional flags to pass to pytest, i.e., markers
     required: false
     default: ""
-  cubit-root:
-    description: Path to the cubit installation
+  cubitpy_config_path:
+    description: Path to the CubitPy config file
     required: false
     default: ""
 runs:
@@ -18,7 +18,7 @@ runs:
         BEAMME_FOUR_C_EXE: /home/user/4C/bin/4C
         OMPI_MCA_rmaps_base_oversubscribe: 1
       run: |
-        export CUBIT_ROOT=${{ inputs.cubit-root }}
+        export CUBITPY_CONFIG_PATH=${{ inputs.cubitpy_config_path }}
         cd ${GITHUB_WORKSPACE}
         TEMP_DIR="${RUNNER_TEMP}/beamme_pytest"
         mkdir -p "$TEMP_DIR"

--- a/.github/workflows/testing_protected.yml
+++ b/.github/workflows/testing_protected.yml
@@ -54,11 +54,16 @@ jobs:
           cubit_download_url: ${{ env.CUBIT_DOWNLOAD_URL }}
           cubit_email: ${{ secrets.CUBIT_EMAIL }}
           cubit_password: ${{ secrets.CUBIT_PASSWORD }}
+      - name: Setup CubitPy config
+        uses: ./.github/actions/cubitpy_config
+        id: cubitpy_config
+        with:
+          cubit-root: ${{ steps.cubit.outputs.cubit_root }}
       - name: Run the test suite and upload results on failure
         uses: ./.github/actions/run_tests
         with:
           additional-pytest-flags: "--4C --ArborX --Coreform --check-for-unused-reference-files --cov-fail-under=93"
-          cubit-root: ${{ steps.cubit.outputs.cubit_root }}
+          cubitpy_config_path: ${{ steps.cubitpy_config.outputs.cubitpy_config_path }}
       - name: Free cubit license
         if: ${{ always() }}
         uses: ./.github/actions/cubit_finalize
@@ -104,11 +109,16 @@ jobs:
           cubit_download_url: ${{ env.CUBIT_DOWNLOAD_URL }}
           cubit_email: ${{ secrets.CUBIT_EMAIL }}
           cubit_password: ${{ secrets.CUBIT_PASSWORD }}
+      - name: Setup CubitPy config
+        uses: ./.github/actions/cubitpy_config
+        id: cubitpy_config
+        with:
+          cubit-root: ${{ steps.cubit.outputs.cubit_root }}
       - name: Run the test suite and upload results on failure
         uses: ./.github/actions/run_tests
         with:
           additional-pytest-flags: "--performance-tests --Coreform --exclude-standard-tests -s --no-cov"
-          cubit-root: ${{ steps.cubit.outputs.cubit_root }}
+          cubitpy_config_path: ${{ steps.cubitpy_config.outputs.cubitpy_config_path }}
       - name: Free cubit license
         if: ${{ always() }}
         uses: ./.github/actions/cubit_finalize

--- a/README.md
+++ b/README.md
@@ -372,8 +372,8 @@ These flags can be combined arbitrarily; for example, to run the 4C, Coreform Cu
 ```bash
 # 4C Tests require a path to a 4C executable
 export BEAMME_FOUR_C_EXE=<path_to_4C>
-# Coreform Tests require a path to a Coreform Cubit installation
-export CUBIT_ROOT=<path_to_Cubit_or_Coreform>
+# Coreform Tests require a path to a CubitPy configuration file
+export CUBITPY_CONFIG_PATH=<path_to_CubitPy_config_file>
 
 pytest --4C --ArborX --Coreform --exclude-standard-tests
 ```


### PR DESCRIPTION
New versions of CubitPy need a configuration file. This PR adds this in the BeamMe testing workflow.

This closes #584