### PR TITLE
Skip CubitPy warnings

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -71,3 +71,8 @@ markers = [
   "coreform: tests in combination with Coreform Cubit",
   "performance: performance tests"
 ]
+filterwarnings = [
+  # Ignore warnings coming from CubitPy, as they are only related to testing scripts
+  # and not directly to BeamMe code.
+  "ignore::cubitpy.conf.CubitPyWarning",
+]


### PR DESCRIPTION
This PR skips all warnings coming from CubitPy in testing.

Ideally, we rework the code that causes the warnings, however, for testing purposes this is not always possible.

Depends on:
- #658
- https://github.com/imcs-compsim/cubitpy/actions/runs/27759889949/job/82131196366?pr=137 + a new CubitPy release