### PR TITLE
Fix test with all dependencies

### DIFF
--- a/.github/workflows/testing_protected.yml
+++ b/.github/workflows/testing_protected.yml
@@ -45,6 +45,8 @@ jobs:
         uses: ./.github/actions/build_arborx_geometric_search
       - name: Install BeamMe
         uses: ./.github/actions/install_beamme
+        with:
+          install-command: "-e .[cubitpy,dev,fourc]"
       - name: Setup cubit
         id: cubit
         uses: ./.github/actions/cubit_setup


### PR DESCRIPTION
This was tricky to find, but with #651 the pip installation in the all dependencies run was accidentally changed to non-editable mode which causes failing ArborX tests.

This is now fixed, but will only work once merged to `main`.