### PR TITLE
Fix geometry type of space-time node sets

### DIFF
--- a/src/beamme/space_time/beam_to_space_time.py
+++ b/src/beamme/space_time/beam_to_space_time.py
@@ -32,13 +32,13 @@ from beamme.core.conf import bme as _bme
 from beamme.core.coupling import Coupling as _Coupling
 from beamme.core.element_volume import VolumeElement as _VolumeElement
 from beamme.core.geometry_set import GeometryName as _GeometryName
-from beamme.core.geometry_set import GeometrySet as _GeometrySet
 from beamme.core.geometry_set import GeometrySetNodes as _GeometrySetNodes
 from beamme.core.mesh import Mesh as _Mesh
 from beamme.core.mesh_representation import MeshRepresentation as _MeshRepresentation
 from beamme.core.mesh_utils import (
     apply_nodal_coupling_to_mesh_representation as _apply_nodal_coupling_to_mesh_representation,
 )
+from beamme.core.node import Node as _Node
 from beamme.core.node import NodeCosserat as _NodeCosserat
 
 
@@ -144,9 +144,11 @@ def beam_to_space_time(
         node.i_global = i_node
 
     # Get the nodes for the final space-time mesh
-    left_nodes = []
-    right_nodes = []
+    left_nodes: list[_Node] = []
+    right_nodes: list[_Node] = []
     space_time_nodes = []
+    start_nodes: list[_Node] = []
+    end_nodes: list[_Node] = []
     for i_mesh_space in range(number_of_copies_in_time):
         time = time_increment_between_nodes * i_mesh_space + time_start
 
@@ -171,9 +173,9 @@ def beam_to_space_time(
         space_time_nodes.extend(space_time_nodes_to_add)
 
         if i_mesh_space == 0:
-            start_nodes = space_time_nodes_to_add
+            start_nodes.extend(space_time_nodes_to_add)
         elif i_mesh_space == number_of_copies_in_time - 1:
-            end_nodes = space_time_nodes_to_add
+            end_nodes.extend(space_time_nodes_to_add)
 
         left_nodes.append(space_time_nodes_to_add[0])
         right_nodes.append(space_time_nodes_to_add[-1])
@@ -259,10 +261,10 @@ def beam_to_space_time(
 
     # Create the element sets
     return_set = _GeometryName()
-    return_set["start"] = _GeometrySet(start_nodes)
-    return_set["end"] = _GeometrySet(end_nodes)
-    return_set["left"] = _GeometrySet(left_nodes)
-    return_set["right"] = _GeometrySet(right_nodes)
+    return_set["start"] = _GeometrySetNodes(_bme.geo.line, start_nodes)
+    return_set["end"] = _GeometrySetNodes(_bme.geo.line, end_nodes)
+    return_set["left"] = _GeometrySetNodes(_bme.geo.line, left_nodes)
+    return_set["right"] = _GeometrySetNodes(_bme.geo.line, right_nodes)
     return_set["surface"] = _GeometrySetNodes(_bme.geo.surface, space_time_mesh.nodes)
 
     return space_time_mesh, return_set

--- a/tests/reference-files/test_integration_space_time_curved_linear.vtu
+++ b/tests/reference-files/test_integration_space_time_curved_linear.vtu
@@ -37,25 +37,25 @@
           4.140000000000001 4.140000000000001 4.140000000000001 4.140000000000001 5.5200000000000005 5.5200000000000005
           5.5200000000000005 5.5200000000000005 6.9 6.9 6.9 6.9
         </DataArray>
-        <DataArray type="Int64" Name="geometry_set_0_point" format="ascii" RangeMin="0" RangeMax="1">
+        <DataArray type="Int64" Name="geometry_set_0_line" format="ascii" RangeMin="0" RangeMax="1">
           0 0 0 0 0 0
           0 0 0 0 0 0
           0 0 0 0 0 0
           0 0 1 1 1 1
         </DataArray>
-        <DataArray type="Int64" Name="geometry_set_1_point" format="ascii" RangeMin="0" RangeMax="1">
+        <DataArray type="Int64" Name="geometry_set_1_line" format="ascii" RangeMin="0" RangeMax="1">
           1 0 0 0 1 0
           0 0 1 0 0 0
           1 0 0 0 1 0
           0 0 1 0 0 0
         </DataArray>
-        <DataArray type="Int64" Name="geometry_set_2_point" format="ascii" RangeMin="0" RangeMax="1">
+        <DataArray type="Int64" Name="geometry_set_2_line" format="ascii" RangeMin="0" RangeMax="1">
           0 0 0 1 0 0
           0 1 0 0 0 1
           0 0 0 1 0 0
           0 1 0 0 0 1
         </DataArray>
-        <DataArray type="Int64" Name="geometry_set_3_point" format="ascii" RangeMin="0" RangeMax="1">
+        <DataArray type="Int64" Name="geometry_set_3_line" format="ascii" RangeMin="0" RangeMax="1">
           1 1 1 1 0 0
           0 0 0 0 0 0
           0 0 0 0 0 0

--- a/tests/reference-files/test_integration_space_time_curved_quadratic.vtu
+++ b/tests/reference-files/test_integration_space_time_curved_quadratic.vtu
@@ -82,7 +82,7 @@
           6.210000000000001 6.210000000000001 6.210000000000001 6.210000000000001 6.9 6.9
           6.9 6.9 6.9 6.9 6.9
         </DataArray>
-        <DataArray type="Int64" Name="geometry_set_0_point" format="ascii" RangeMin="0" RangeMax="1">
+        <DataArray type="Int64" Name="geometry_set_0_line" format="ascii" RangeMin="0" RangeMax="1">
           0 0 0 0 0 0
           0 0 0 0 0 0
           0 0 0 0 0 0
@@ -97,7 +97,7 @@
           0 0 0 0 1 1
           1 1 1 1 1
         </DataArray>
-        <DataArray type="Int64" Name="geometry_set_1_point" format="ascii" RangeMin="0" RangeMax="1">
+        <DataArray type="Int64" Name="geometry_set_1_line" format="ascii" RangeMin="0" RangeMax="1">
           1 0 0 0 0 0
           0 1 0 0 0 0
           0 0 1 0 0 0
@@ -112,7 +112,7 @@
           0 0 0 0 1 0
           0 0 0 0 0
         </DataArray>
-        <DataArray type="Int64" Name="geometry_set_2_point" format="ascii" RangeMin="0" RangeMax="1">
+        <DataArray type="Int64" Name="geometry_set_2_line" format="ascii" RangeMin="0" RangeMax="1">
           0 0 0 0 0 0
           1 0 0 0 0 0
           0 1 0 0 0 0
@@ -127,7 +127,7 @@
           0 0 0 1 0 0
           0 0 0 0 1
         </DataArray>
-        <DataArray type="Int64" Name="geometry_set_3_point" format="ascii" RangeMin="0" RangeMax="1">
+        <DataArray type="Int64" Name="geometry_set_3_line" format="ascii" RangeMin="0" RangeMax="1">
           1 1 1 1 1 1
           1 0 0 0 0 0
           0 0 0 0 0 0

--- a/tests/reference-files/test_integration_space_time_elbow_linear.vtu
+++ b/tests/reference-files/test_integration_space_time_elbow_linear.vtu
@@ -52,7 +52,7 @@
           7.210000000000001 7.210000000000001 7.210000000000001 7.210000000000001 7.210000000000001 8.59
           8.59 8.59 8.59 8.59 8.59 8.59
         </DataArray>
-        <DataArray type="Int64" Name="geometry_set_0_point" format="ascii" RangeMin="0" RangeMax="1">
+        <DataArray type="Int64" Name="geometry_set_0_line" format="ascii" RangeMin="0" RangeMax="1">
           0 0 0 0 0 0
           0 0 0 0 0 0
           0 0 0 0 0 0
@@ -61,7 +61,7 @@
           0 0 0 0 0 1
           1 1 1 1 1 1
         </DataArray>
-        <DataArray type="Int64" Name="geometry_set_1_point" format="ascii" RangeMin="0" RangeMax="1">
+        <DataArray type="Int64" Name="geometry_set_1_line" format="ascii" RangeMin="0" RangeMax="1">
           1 0 0 0 0 0
           0 1 0 0 0 0
           0 0 1 0 0 0
@@ -70,7 +70,7 @@
           0 0 0 0 0 1
           0 0 0 0 0 0
         </DataArray>
-        <DataArray type="Int64" Name="geometry_set_2_point" format="ascii" RangeMin="0" RangeMax="1">
+        <DataArray type="Int64" Name="geometry_set_2_line" format="ascii" RangeMin="0" RangeMax="1">
           0 0 0 0 0 0
           1 0 0 0 0 0
           0 1 0 0 0 0
@@ -79,7 +79,7 @@
           0 0 0 0 1 0
           0 0 0 0 0 1
         </DataArray>
-        <DataArray type="Int64" Name="geometry_set_3_point" format="ascii" RangeMin="0" RangeMax="1">
+        <DataArray type="Int64" Name="geometry_set_3_line" format="ascii" RangeMin="0" RangeMax="1">
           1 1 1 1 1 1
           1 0 0 0 0 0
           0 0 0 0 0 0

--- a/tests/reference-files/test_integration_space_time_elbow_linear_coupling.vtu
+++ b/tests/reference-files/test_integration_space_time_elbow_linear_coupling.vtu
@@ -48,84 +48,84 @@
           8.59 8.59 8.59 8.59 8.59 8.59
         </DataArray>
         <DataArray type="Int64" Name="geometry_set_0_point" format="ascii" RangeMin="0" RangeMax="1">
+          0 0 0 1 0 0
           0 0 0 0 0 0
           0 0 0 0 0 0
           0 0 0 0 0 0
           0 0 0 0 0 0
           0 0 0 0 0 0
-          1 1 1 1 1 1
         </DataArray>
         <DataArray type="Int64" Name="geometry_set_1_point" format="ascii" RangeMin="0" RangeMax="1">
-          1 0 0 0 0 0
-          1 0 0 0 0 0
-          1 0 0 0 0 0
-          1 0 0 0 0 0
-          1 0 0 0 0 0
-          1 0 0 0 0 0
+          0 0 0 0 0 0
+          0 0 0 1 0 0
+          0 0 0 0 0 0
+          0 0 0 0 0 0
+          0 0 0 0 0 0
+          0 0 0 0 0 0
         </DataArray>
         <DataArray type="Int64" Name="geometry_set_2_point" format="ascii" RangeMin="0" RangeMax="1">
-          0 0 0 0 0 1
-          0 0 0 0 0 1
-          0 0 0 0 0 1
-          0 0 0 0 0 1
-          0 0 0 0 0 1
-          0 0 0 0 0 1
+          0 0 0 0 0 0
+          0 0 0 0 0 0
+          0 0 0 1 0 0
+          0 0 0 0 0 0
+          0 0 0 0 0 0
+          0 0 0 0 0 0
         </DataArray>
         <DataArray type="Int64" Name="geometry_set_3_point" format="ascii" RangeMin="0" RangeMax="1">
-          1 1 1 1 1 1
           0 0 0 0 0 0
           0 0 0 0 0 0
           0 0 0 0 0 0
+          0 0 0 1 0 0
           0 0 0 0 0 0
           0 0 0 0 0 0
         </DataArray>
         <DataArray type="Int64" Name="geometry_set_4_point" format="ascii" RangeMin="0" RangeMax="1">
+          0 0 0 0 0 0
+          0 0 0 0 0 0
+          0 0 0 0 0 0
+          0 0 0 0 0 0
           0 0 0 1 0 0
-          0 0 0 0 0 0
-          0 0 0 0 0 0
-          0 0 0 0 0 0
-          0 0 0 0 0 0
           0 0 0 0 0 0
         </DataArray>
         <DataArray type="Int64" Name="geometry_set_5_point" format="ascii" RangeMin="0" RangeMax="1">
           0 0 0 0 0 0
+          0 0 0 0 0 0
+          0 0 0 0 0 0
+          0 0 0 0 0 0
+          0 0 0 0 0 0
           0 0 0 1 0 0
-          0 0 0 0 0 0
-          0 0 0 0 0 0
-          0 0 0 0 0 0
-          0 0 0 0 0 0
         </DataArray>
-        <DataArray type="Int64" Name="geometry_set_6_point" format="ascii" RangeMin="0" RangeMax="1">
-          0 0 0 0 0 0
-          0 0 0 0 0 0
-          0 0 0 1 0 0
+        <DataArray type="Int64" Name="geometry_set_6_line" format="ascii" RangeMin="0" RangeMax="1">
           0 0 0 0 0 0
           0 0 0 0 0 0
           0 0 0 0 0 0
+          0 0 0 0 0 0
+          0 0 0 0 0 0
+          1 1 1 1 1 1
         </DataArray>
-        <DataArray type="Int64" Name="geometry_set_7_point" format="ascii" RangeMin="0" RangeMax="1">
-          0 0 0 0 0 0
-          0 0 0 0 0 0
-          0 0 0 0 0 0
-          0 0 0 1 0 0
-          0 0 0 0 0 0
-          0 0 0 0 0 0
+        <DataArray type="Int64" Name="geometry_set_7_line" format="ascii" RangeMin="0" RangeMax="1">
+          1 0 0 0 0 0
+          1 0 0 0 0 0
+          1 0 0 0 0 0
+          1 0 0 0 0 0
+          1 0 0 0 0 0
+          1 0 0 0 0 0
         </DataArray>
-        <DataArray type="Int64" Name="geometry_set_8_point" format="ascii" RangeMin="0" RangeMax="1">
-          0 0 0 0 0 0
-          0 0 0 0 0 0
-          0 0 0 0 0 0
-          0 0 0 0 0 0
-          0 0 0 1 0 0
-          0 0 0 0 0 0
+        <DataArray type="Int64" Name="geometry_set_8_line" format="ascii" RangeMin="0" RangeMax="1">
+          0 0 0 0 0 1
+          0 0 0 0 0 1
+          0 0 0 0 0 1
+          0 0 0 0 0 1
+          0 0 0 0 0 1
+          0 0 0 0 0 1
         </DataArray>
-        <DataArray type="Int64" Name="geometry_set_9_point" format="ascii" RangeMin="0" RangeMax="1">
+        <DataArray type="Int64" Name="geometry_set_9_line" format="ascii" RangeMin="0" RangeMax="1">
+          1 1 1 1 1 1
           0 0 0 0 0 0
           0 0 0 0 0 0
           0 0 0 0 0 0
           0 0 0 0 0 0
           0 0 0 0 0 0
-          0 0 0 1 0 0
         </DataArray>
         <DataArray type="Int64" Name="geometry_set_10_surface" format="ascii" RangeMin="1" RangeMax="1">
           1 1 1 1 1 1

--- a/tests/reference-files/test_integration_space_time_elbow_quadratic.vtu
+++ b/tests/reference-files/test_integration_space_time_elbow_quadratic.vtu
@@ -127,7 +127,7 @@
           8.59 8.59 8.59 8.59 8.59 8.59
           8.59 8.59 8.59 8.59 8.59 8.59
         </DataArray>
-        <DataArray type="Int64" Name="geometry_set_0_point" format="ascii" RangeMin="0" RangeMax="1">
+        <DataArray type="Int64" Name="geometry_set_0_line" format="ascii" RangeMin="0" RangeMax="1">
           0 0 0 0 0 0
           0 0 0 0 0 0
           0 0 0 0 0 0
@@ -151,7 +151,7 @@
           1 1 1 1 1 1
           1 1 1 1 1 1
         </DataArray>
-        <DataArray type="Int64" Name="geometry_set_1_point" format="ascii" RangeMin="0" RangeMax="1">
+        <DataArray type="Int64" Name="geometry_set_1_line" format="ascii" RangeMin="0" RangeMax="1">
           1 0 0 0 0 0
           0 0 0 0 0 0
           1 0 0 0 0 0
@@ -175,7 +175,7 @@
           1 0 0 0 0 0
           0 0 0 0 0 0
         </DataArray>
-        <DataArray type="Int64" Name="geometry_set_2_point" format="ascii" RangeMin="0" RangeMax="1">
+        <DataArray type="Int64" Name="geometry_set_2_line" format="ascii" RangeMin="0" RangeMax="1">
           0 0 0 0 0 0
           0 0 0 0 0 1
           0 0 0 0 0 0
@@ -199,7 +199,7 @@
           0 0 0 0 0 0
           0 0 0 0 0 1
         </DataArray>
-        <DataArray type="Int64" Name="geometry_set_3_point" format="ascii" RangeMin="0" RangeMax="1">
+        <DataArray type="Int64" Name="geometry_set_3_line" format="ascii" RangeMin="0" RangeMax="1">
           1 1 1 1 1 1
           1 1 1 1 1 1
           0 0 0 0 0 0

--- a/tests/reference-files/test_integration_space_time_elbow_quadratic_coupling.vtu
+++ b/tests/reference-files/test_integration_space_time_elbow_quadratic_coupling.vtu
@@ -122,6 +122,259 @@
         </DataArray>
         <DataArray type="Int64" Name="geometry_set_0_point" format="ascii" RangeMin="0" RangeMax="1">
           0 0 0 0 0 0
+          1 0 0 0 0 0
+          0 0 0 0 0 0
+          0 0 0 0 0 0
+          0 0 0 0 0 0
+          0 0 0 0 0 0
+          0 0 0 0 0 0
+          0 0 0 0 0 0
+          0 0 0 0 0 0
+          0 0 0 0 0 0
+          0 0 0 0 0 0
+          0 0 0 0 0 0
+          0 0 0 0 0 0
+          0 0 0 0 0 0
+          0 0 0 0 0 0
+          0 0 0 0 0 0
+          0 0 0 0 0 0
+          0 0 0 0 0 0
+          0 0 0 0 0 0
+          0 0 0 0 0 0
+          0
+        </DataArray>
+        <DataArray type="Int64" Name="geometry_set_1_point" format="ascii" RangeMin="0" RangeMax="1">
+          0 0 0 0 0 0
+          0 0 0 0 0 0
+          0 0 0 0 0 1
+          0 0 0 0 0 0
+          0 0 0 0 0 0
+          0 0 0 0 0 0
+          0 0 0 0 0 0
+          0 0 0 0 0 0
+          0 0 0 0 0 0
+          0 0 0 0 0 0
+          0 0 0 0 0 0
+          0 0 0 0 0 0
+          0 0 0 0 0 0
+          0 0 0 0 0 0
+          0 0 0 0 0 0
+          0 0 0 0 0 0
+          0 0 0 0 0 0
+          0 0 0 0 0 0
+          0 0 0 0 0 0
+          0 0 0 0 0 0
+          0
+        </DataArray>
+        <DataArray type="Int64" Name="geometry_set_2_point" format="ascii" RangeMin="0" RangeMax="1">
+          0 0 0 0 0 0
+          0 0 0 0 0 0
+          0 0 0 0 0 0
+          0 0 0 0 0 0
+          0 0 0 0 1 0
+          0 0 0 0 0 0
+          0 0 0 0 0 0
+          0 0 0 0 0 0
+          0 0 0 0 0 0
+          0 0 0 0 0 0
+          0 0 0 0 0 0
+          0 0 0 0 0 0
+          0 0 0 0 0 0
+          0 0 0 0 0 0
+          0 0 0 0 0 0
+          0 0 0 0 0 0
+          0 0 0 0 0 0
+          0 0 0 0 0 0
+          0 0 0 0 0 0
+          0 0 0 0 0 0
+          0
+        </DataArray>
+        <DataArray type="Int64" Name="geometry_set_3_point" format="ascii" RangeMin="0" RangeMax="1">
+          0 0 0 0 0 0
+          0 0 0 0 0 0
+          0 0 0 0 0 0
+          0 0 0 0 0 0
+          0 0 0 0 0 0
+          0 0 0 0 0 0
+          0 0 0 1 0 0
+          0 0 0 0 0 0
+          0 0 0 0 0 0
+          0 0 0 0 0 0
+          0 0 0 0 0 0
+          0 0 0 0 0 0
+          0 0 0 0 0 0
+          0 0 0 0 0 0
+          0 0 0 0 0 0
+          0 0 0 0 0 0
+          0 0 0 0 0 0
+          0 0 0 0 0 0
+          0 0 0 0 0 0
+          0 0 0 0 0 0
+          0
+        </DataArray>
+        <DataArray type="Int64" Name="geometry_set_4_point" format="ascii" RangeMin="0" RangeMax="1">
+          0 0 0 0 0 0
+          0 0 0 0 0 0
+          0 0 0 0 0 0
+          0 0 0 0 0 0
+          0 0 0 0 0 0
+          0 0 0 0 0 0
+          0 0 0 0 0 0
+          0 0 0 0 0 0
+          0 0 1 0 0 0
+          0 0 0 0 0 0
+          0 0 0 0 0 0
+          0 0 0 0 0 0
+          0 0 0 0 0 0
+          0 0 0 0 0 0
+          0 0 0 0 0 0
+          0 0 0 0 0 0
+          0 0 0 0 0 0
+          0 0 0 0 0 0
+          0 0 0 0 0 0
+          0 0 0 0 0 0
+          0
+        </DataArray>
+        <DataArray type="Int64" Name="geometry_set_5_point" format="ascii" RangeMin="0" RangeMax="1">
+          0 0 0 0 0 0
+          0 0 0 0 0 0
+          0 0 0 0 0 0
+          0 0 0 0 0 0
+          0 0 0 0 0 0
+          0 0 0 0 0 0
+          0 0 0 0 0 0
+          0 0 0 0 0 0
+          0 0 0 0 0 0
+          0 0 0 0 0 0
+          0 1 0 0 0 0
+          0 0 0 0 0 0
+          0 0 0 0 0 0
+          0 0 0 0 0 0
+          0 0 0 0 0 0
+          0 0 0 0 0 0
+          0 0 0 0 0 0
+          0 0 0 0 0 0
+          0 0 0 0 0 0
+          0 0 0 0 0 0
+          0
+        </DataArray>
+        <DataArray type="Int64" Name="geometry_set_6_point" format="ascii" RangeMin="0" RangeMax="1">
+          0 0 0 0 0 0
+          0 0 0 0 0 0
+          0 0 0 0 0 0
+          0 0 0 0 0 0
+          0 0 0 0 0 0
+          0 0 0 0 0 0
+          0 0 0 0 0 0
+          0 0 0 0 0 0
+          0 0 0 0 0 0
+          0 0 0 0 0 0
+          0 0 0 0 0 0
+          0 0 0 0 0 0
+          1 0 0 0 0 0
+          0 0 0 0 0 0
+          0 0 0 0 0 0
+          0 0 0 0 0 0
+          0 0 0 0 0 0
+          0 0 0 0 0 0
+          0 0 0 0 0 0
+          0 0 0 0 0 0
+          0
+        </DataArray>
+        <DataArray type="Int64" Name="geometry_set_7_point" format="ascii" RangeMin="0" RangeMax="1">
+          0 0 0 0 0 0
+          0 0 0 0 0 0
+          0 0 0 0 0 0
+          0 0 0 0 0 0
+          0 0 0 0 0 0
+          0 0 0 0 0 0
+          0 0 0 0 0 0
+          0 0 0 0 0 0
+          0 0 0 0 0 0
+          0 0 0 0 0 0
+          0 0 0 0 0 0
+          0 0 0 0 0 0
+          0 0 0 0 0 0
+          0 0 0 0 0 1
+          0 0 0 0 0 0
+          0 0 0 0 0 0
+          0 0 0 0 0 0
+          0 0 0 0 0 0
+          0 0 0 0 0 0
+          0 0 0 0 0 0
+          0
+        </DataArray>
+        <DataArray type="Int64" Name="geometry_set_8_point" format="ascii" RangeMin="0" RangeMax="1">
+          0 0 0 0 0 0
+          0 0 0 0 0 0
+          0 0 0 0 0 0
+          0 0 0 0 0 0
+          0 0 0 0 0 0
+          0 0 0 0 0 0
+          0 0 0 0 0 0
+          0 0 0 0 0 0
+          0 0 0 0 0 0
+          0 0 0 0 0 0
+          0 0 0 0 0 0
+          0 0 0 0 0 0
+          0 0 0 0 0 0
+          0 0 0 0 0 0
+          0 0 0 0 0 0
+          0 0 0 0 1 0
+          0 0 0 0 0 0
+          0 0 0 0 0 0
+          0 0 0 0 0 0
+          0 0 0 0 0 0
+          0
+        </DataArray>
+        <DataArray type="Int64" Name="geometry_set_9_point" format="ascii" RangeMin="0" RangeMax="1">
+          0 0 0 0 0 0
+          0 0 0 0 0 0
+          0 0 0 0 0 0
+          0 0 0 0 0 0
+          0 0 0 0 0 0
+          0 0 0 0 0 0
+          0 0 0 0 0 0
+          0 0 0 0 0 0
+          0 0 0 0 0 0
+          0 0 0 0 0 0
+          0 0 0 0 0 0
+          0 0 0 0 0 0
+          0 0 0 0 0 0
+          0 0 0 0 0 0
+          0 0 0 0 0 0
+          0 0 0 0 0 0
+          0 0 0 0 0 0
+          0 0 0 1 0 0
+          0 0 0 0 0 0
+          0 0 0 0 0 0
+          0
+        </DataArray>
+        <DataArray type="Int64" Name="geometry_set_10_point" format="ascii" RangeMin="0" RangeMax="1">
+          0 0 0 0 0 0
+          0 0 0 0 0 0
+          0 0 0 0 0 0
+          0 0 0 0 0 0
+          0 0 0 0 0 0
+          0 0 0 0 0 0
+          0 0 0 0 0 0
+          0 0 0 0 0 0
+          0 0 0 0 0 0
+          0 0 0 0 0 0
+          0 0 0 0 0 0
+          0 0 0 0 0 0
+          0 0 0 0 0 0
+          0 0 0 0 0 0
+          0 0 0 0 0 0
+          0 0 0 0 0 0
+          0 0 0 0 0 0
+          0 0 0 0 0 0
+          0 0 0 0 0 0
+          0 0 1 0 0 0
+          0
+        </DataArray>
+        <DataArray type="Int64" Name="geometry_set_11_line" format="ascii" RangeMin="0" RangeMax="1">
+          0 0 0 0 0 0
           0 0 0 0 0 0
           0 0 0 0 0 0
           0 0 0 0 0 0
@@ -143,7 +396,7 @@
           1 1 1 1 1 1
           1
         </DataArray>
-        <DataArray type="Int64" Name="geometry_set_1_point" format="ascii" RangeMin="0" RangeMax="1">
+        <DataArray type="Int64" Name="geometry_set_12_line" format="ascii" RangeMin="0" RangeMax="1">
           1 0 0 0 0 0
           0 0 0 0 0 1
           0 0 0 0 0 0
@@ -166,7 +419,7 @@
           0 0 0 0 0 0
           0
         </DataArray>
-        <DataArray type="Int64" Name="geometry_set_2_point" format="ascii" RangeMin="0" RangeMax="1">
+        <DataArray type="Int64" Name="geometry_set_13_line" format="ascii" RangeMin="0" RangeMax="1">
           0 0 0 0 0 0
           0 0 0 0 1 0
           0 0 0 0 0 0
@@ -189,7 +442,7 @@
           0 0 0 0 0 0
           1
         </DataArray>
-        <DataArray type="Int64" Name="geometry_set_3_point" format="ascii" RangeMin="0" RangeMax="1">
+        <DataArray type="Int64" Name="geometry_set_14_line" format="ascii" RangeMin="0" RangeMax="1">
           1 1 1 1 1 1
           1 1 1 1 1 0
           0 0 0 0 0 0
@@ -210,259 +463,6 @@
           0 0 0 0 0 0
           0 0 0 0 0 0
           0 0 0 0 0 0
-          0
-        </DataArray>
-        <DataArray type="Int64" Name="geometry_set_4_point" format="ascii" RangeMin="0" RangeMax="1">
-          0 0 0 0 0 0
-          1 0 0 0 0 0
-          0 0 0 0 0 0
-          0 0 0 0 0 0
-          0 0 0 0 0 0
-          0 0 0 0 0 0
-          0 0 0 0 0 0
-          0 0 0 0 0 0
-          0 0 0 0 0 0
-          0 0 0 0 0 0
-          0 0 0 0 0 0
-          0 0 0 0 0 0
-          0 0 0 0 0 0
-          0 0 0 0 0 0
-          0 0 0 0 0 0
-          0 0 0 0 0 0
-          0 0 0 0 0 0
-          0 0 0 0 0 0
-          0 0 0 0 0 0
-          0 0 0 0 0 0
-          0
-        </DataArray>
-        <DataArray type="Int64" Name="geometry_set_5_point" format="ascii" RangeMin="0" RangeMax="1">
-          0 0 0 0 0 0
-          0 0 0 0 0 0
-          0 0 0 0 0 1
-          0 0 0 0 0 0
-          0 0 0 0 0 0
-          0 0 0 0 0 0
-          0 0 0 0 0 0
-          0 0 0 0 0 0
-          0 0 0 0 0 0
-          0 0 0 0 0 0
-          0 0 0 0 0 0
-          0 0 0 0 0 0
-          0 0 0 0 0 0
-          0 0 0 0 0 0
-          0 0 0 0 0 0
-          0 0 0 0 0 0
-          0 0 0 0 0 0
-          0 0 0 0 0 0
-          0 0 0 0 0 0
-          0 0 0 0 0 0
-          0
-        </DataArray>
-        <DataArray type="Int64" Name="geometry_set_6_point" format="ascii" RangeMin="0" RangeMax="1">
-          0 0 0 0 0 0
-          0 0 0 0 0 0
-          0 0 0 0 0 0
-          0 0 0 0 0 0
-          0 0 0 0 1 0
-          0 0 0 0 0 0
-          0 0 0 0 0 0
-          0 0 0 0 0 0
-          0 0 0 0 0 0
-          0 0 0 0 0 0
-          0 0 0 0 0 0
-          0 0 0 0 0 0
-          0 0 0 0 0 0
-          0 0 0 0 0 0
-          0 0 0 0 0 0
-          0 0 0 0 0 0
-          0 0 0 0 0 0
-          0 0 0 0 0 0
-          0 0 0 0 0 0
-          0 0 0 0 0 0
-          0
-        </DataArray>
-        <DataArray type="Int64" Name="geometry_set_7_point" format="ascii" RangeMin="0" RangeMax="1">
-          0 0 0 0 0 0
-          0 0 0 0 0 0
-          0 0 0 0 0 0
-          0 0 0 0 0 0
-          0 0 0 0 0 0
-          0 0 0 0 0 0
-          0 0 0 1 0 0
-          0 0 0 0 0 0
-          0 0 0 0 0 0
-          0 0 0 0 0 0
-          0 0 0 0 0 0
-          0 0 0 0 0 0
-          0 0 0 0 0 0
-          0 0 0 0 0 0
-          0 0 0 0 0 0
-          0 0 0 0 0 0
-          0 0 0 0 0 0
-          0 0 0 0 0 0
-          0 0 0 0 0 0
-          0 0 0 0 0 0
-          0
-        </DataArray>
-        <DataArray type="Int64" Name="geometry_set_8_point" format="ascii" RangeMin="0" RangeMax="1">
-          0 0 0 0 0 0
-          0 0 0 0 0 0
-          0 0 0 0 0 0
-          0 0 0 0 0 0
-          0 0 0 0 0 0
-          0 0 0 0 0 0
-          0 0 0 0 0 0
-          0 0 0 0 0 0
-          0 0 1 0 0 0
-          0 0 0 0 0 0
-          0 0 0 0 0 0
-          0 0 0 0 0 0
-          0 0 0 0 0 0
-          0 0 0 0 0 0
-          0 0 0 0 0 0
-          0 0 0 0 0 0
-          0 0 0 0 0 0
-          0 0 0 0 0 0
-          0 0 0 0 0 0
-          0 0 0 0 0 0
-          0
-        </DataArray>
-        <DataArray type="Int64" Name="geometry_set_9_point" format="ascii" RangeMin="0" RangeMax="1">
-          0 0 0 0 0 0
-          0 0 0 0 0 0
-          0 0 0 0 0 0
-          0 0 0 0 0 0
-          0 0 0 0 0 0
-          0 0 0 0 0 0
-          0 0 0 0 0 0
-          0 0 0 0 0 0
-          0 0 0 0 0 0
-          0 0 0 0 0 0
-          0 1 0 0 0 0
-          0 0 0 0 0 0
-          0 0 0 0 0 0
-          0 0 0 0 0 0
-          0 0 0 0 0 0
-          0 0 0 0 0 0
-          0 0 0 0 0 0
-          0 0 0 0 0 0
-          0 0 0 0 0 0
-          0 0 0 0 0 0
-          0
-        </DataArray>
-        <DataArray type="Int64" Name="geometry_set_10_point" format="ascii" RangeMin="0" RangeMax="1">
-          0 0 0 0 0 0
-          0 0 0 0 0 0
-          0 0 0 0 0 0
-          0 0 0 0 0 0
-          0 0 0 0 0 0
-          0 0 0 0 0 0
-          0 0 0 0 0 0
-          0 0 0 0 0 0
-          0 0 0 0 0 0
-          0 0 0 0 0 0
-          0 0 0 0 0 0
-          0 0 0 0 0 0
-          1 0 0 0 0 0
-          0 0 0 0 0 0
-          0 0 0 0 0 0
-          0 0 0 0 0 0
-          0 0 0 0 0 0
-          0 0 0 0 0 0
-          0 0 0 0 0 0
-          0 0 0 0 0 0
-          0
-        </DataArray>
-        <DataArray type="Int64" Name="geometry_set_11_point" format="ascii" RangeMin="0" RangeMax="1">
-          0 0 0 0 0 0
-          0 0 0 0 0 0
-          0 0 0 0 0 0
-          0 0 0 0 0 0
-          0 0 0 0 0 0
-          0 0 0 0 0 0
-          0 0 0 0 0 0
-          0 0 0 0 0 0
-          0 0 0 0 0 0
-          0 0 0 0 0 0
-          0 0 0 0 0 0
-          0 0 0 0 0 0
-          0 0 0 0 0 0
-          0 0 0 0 0 1
-          0 0 0 0 0 0
-          0 0 0 0 0 0
-          0 0 0 0 0 0
-          0 0 0 0 0 0
-          0 0 0 0 0 0
-          0 0 0 0 0 0
-          0
-        </DataArray>
-        <DataArray type="Int64" Name="geometry_set_12_point" format="ascii" RangeMin="0" RangeMax="1">
-          0 0 0 0 0 0
-          0 0 0 0 0 0
-          0 0 0 0 0 0
-          0 0 0 0 0 0
-          0 0 0 0 0 0
-          0 0 0 0 0 0
-          0 0 0 0 0 0
-          0 0 0 0 0 0
-          0 0 0 0 0 0
-          0 0 0 0 0 0
-          0 0 0 0 0 0
-          0 0 0 0 0 0
-          0 0 0 0 0 0
-          0 0 0 0 0 0
-          0 0 0 0 0 0
-          0 0 0 0 1 0
-          0 0 0 0 0 0
-          0 0 0 0 0 0
-          0 0 0 0 0 0
-          0 0 0 0 0 0
-          0
-        </DataArray>
-        <DataArray type="Int64" Name="geometry_set_13_point" format="ascii" RangeMin="0" RangeMax="1">
-          0 0 0 0 0 0
-          0 0 0 0 0 0
-          0 0 0 0 0 0
-          0 0 0 0 0 0
-          0 0 0 0 0 0
-          0 0 0 0 0 0
-          0 0 0 0 0 0
-          0 0 0 0 0 0
-          0 0 0 0 0 0
-          0 0 0 0 0 0
-          0 0 0 0 0 0
-          0 0 0 0 0 0
-          0 0 0 0 0 0
-          0 0 0 0 0 0
-          0 0 0 0 0 0
-          0 0 0 0 0 0
-          0 0 0 0 0 0
-          0 0 0 1 0 0
-          0 0 0 0 0 0
-          0 0 0 0 0 0
-          0
-        </DataArray>
-        <DataArray type="Int64" Name="geometry_set_14_point" format="ascii" RangeMin="0" RangeMax="1">
-          0 0 0 0 0 0
-          0 0 0 0 0 0
-          0 0 0 0 0 0
-          0 0 0 0 0 0
-          0 0 0 0 0 0
-          0 0 0 0 0 0
-          0 0 0 0 0 0
-          0 0 0 0 0 0
-          0 0 0 0 0 0
-          0 0 0 0 0 0
-          0 0 0 0 0 0
-          0 0 0 0 0 0
-          0 0 0 0 0 0
-          0 0 0 0 0 0
-          0 0 0 0 0 0
-          0 0 0 0 0 0
-          0 0 0 0 0 0
-          0 0 0 0 0 0
-          0 0 0 0 0 0
-          0 0 1 0 0 0
           0
         </DataArray>
         <DataArray type="Int64" Name="geometry_set_15_surface" format="ascii" RangeMin="1" RangeMax="1">

--- a/tests/reference-files/test_integration_space_time_named_node_set.vtu
+++ b/tests/reference-files/test_integration_space_time_named_node_set.vtu
@@ -27,19 +27,19 @@
           2.5 2.5 2.5 4.800000000000001 4.800000000000001 4.800000000000001
           7.1000000000000005 7.1000000000000005 7.1000000000000005 9.4 9.4 9.4
         </DataArray>
-        <DataArray type="Int64" Name="geometry_set_0_point" format="ascii" RangeMin="0" RangeMax="1">
+        <DataArray type="Int64" Name="geometry_set_0_line" format="ascii" RangeMin="0" RangeMax="1">
           0 0 0 0 0 0
           0 0 0 1 1 1
         </DataArray>
-        <DataArray type="Int64" Name="geometry_set_1_point" format="ascii" RangeMin="0" RangeMax="1">
+        <DataArray type="Int64" Name="geometry_set_1_line" format="ascii" RangeMin="0" RangeMax="1">
           1 0 0 1 0 0
           1 0 0 1 0 0
         </DataArray>
-        <DataArray type="Int64" Name="geometry_set_2_point_right" format="ascii" RangeMin="0" RangeMax="1">
+        <DataArray type="Int64" Name="geometry_set_2_line_right" format="ascii" RangeMin="0" RangeMax="1">
           0 0 1 0 0 1
           0 0 1 0 0 1
         </DataArray>
-        <DataArray type="Int64" Name="geometry_set_3_point_start" format="ascii" RangeMin="0" RangeMax="1">
+        <DataArray type="Int64" Name="geometry_set_3_line_start" format="ascii" RangeMin="0" RangeMax="1">
           1 1 1 0 0 0
           0 0 0 0 0 0
         </DataArray>

--- a/tests/reference-files/test_integration_space_time_straight_linear.vtu
+++ b/tests/reference-files/test_integration_space_time_straight_linear.vtu
@@ -37,25 +37,25 @@
           6.640000000000001 6.640000000000001 6.640000000000001 6.640000000000001 8.02 8.02
           8.02 8.02 9.4 9.4 9.4 9.4
         </DataArray>
-        <DataArray type="Int64" Name="geometry_set_0_point" format="ascii" RangeMin="0" RangeMax="1">
+        <DataArray type="Int64" Name="geometry_set_0_line" format="ascii" RangeMin="0" RangeMax="1">
           0 0 0 0 0 0
           0 0 0 0 0 0
           0 0 0 0 0 0
           0 0 1 1 1 1
         </DataArray>
-        <DataArray type="Int64" Name="geometry_set_1_point" format="ascii" RangeMin="0" RangeMax="1">
+        <DataArray type="Int64" Name="geometry_set_1_line" format="ascii" RangeMin="0" RangeMax="1">
           1 0 0 0 1 0
           0 0 1 0 0 0
           1 0 0 0 1 0
           0 0 1 0 0 0
         </DataArray>
-        <DataArray type="Int64" Name="geometry_set_2_point" format="ascii" RangeMin="0" RangeMax="1">
+        <DataArray type="Int64" Name="geometry_set_2_line" format="ascii" RangeMin="0" RangeMax="1">
           0 0 0 1 0 0
           0 1 0 0 0 1
           0 0 0 1 0 0
           0 1 0 0 0 1
         </DataArray>
-        <DataArray type="Int64" Name="geometry_set_3_point" format="ascii" RangeMin="0" RangeMax="1">
+        <DataArray type="Int64" Name="geometry_set_3_line" format="ascii" RangeMin="0" RangeMax="1">
           1 1 1 1 0 0
           0 0 0 0 0 0
           0 0 0 0 0 0

--- a/tests/reference-files/test_integration_space_time_straight_quadratic.vtu
+++ b/tests/reference-files/test_integration_space_time_straight_quadratic.vtu
@@ -82,7 +82,7 @@
           8.71 8.71 8.71 8.71 9.4 9.4
           9.4 9.4 9.4 9.4 9.4
         </DataArray>
-        <DataArray type="Int64" Name="geometry_set_0_point" format="ascii" RangeMin="0" RangeMax="1">
+        <DataArray type="Int64" Name="geometry_set_0_line" format="ascii" RangeMin="0" RangeMax="1">
           0 0 0 0 0 0
           0 0 0 0 0 0
           0 0 0 0 0 0
@@ -97,7 +97,7 @@
           0 0 0 0 1 1
           1 1 1 1 1
         </DataArray>
-        <DataArray type="Int64" Name="geometry_set_1_point" format="ascii" RangeMin="0" RangeMax="1">
+        <DataArray type="Int64" Name="geometry_set_1_line" format="ascii" RangeMin="0" RangeMax="1">
           1 0 0 0 0 0
           0 1 0 0 0 0
           0 0 1 0 0 0
@@ -112,7 +112,7 @@
           0 0 0 0 1 0
           0 0 0 0 0
         </DataArray>
-        <DataArray type="Int64" Name="geometry_set_2_point" format="ascii" RangeMin="0" RangeMax="1">
+        <DataArray type="Int64" Name="geometry_set_2_line" format="ascii" RangeMin="0" RangeMax="1">
           0 0 0 0 0 0
           1 0 0 0 0 0
           0 1 0 0 0 0
@@ -127,7 +127,7 @@
           0 0 0 1 0 0
           0 0 0 0 1
         </DataArray>
-        <DataArray type="Int64" Name="geometry_set_3_point" format="ascii" RangeMin="0" RangeMax="1">
+        <DataArray type="Int64" Name="geometry_set_3_line" format="ascii" RangeMin="0" RangeMax="1">
           1 1 1 1 1 1
           1 0 0 0 0 0
           0 0 0 0 0 0

--- a/tests/reference-files/test_integration_space_time_varying_material_length_linear.vtu
+++ b/tests/reference-files/test_integration_space_time_varying_material_length_linear.vtu
@@ -52,7 +52,7 @@
           7.210000000000001 7.210000000000001 7.210000000000001 7.210000000000001 7.210000000000001 8.59
           8.59 8.59 8.59 8.59 8.59 8.59
         </DataArray>
-        <DataArray type="Int64" Name="geometry_set_0_point" format="ascii" RangeMin="0" RangeMax="1">
+        <DataArray type="Int64" Name="geometry_set_0_line" format="ascii" RangeMin="0" RangeMax="1">
           0 0 0 0 0 0
           0 0 0 0 0 0
           0 0 0 0 0 0
@@ -61,7 +61,7 @@
           0 0 0 0 0 1
           1 1 1 1 1 1
         </DataArray>
-        <DataArray type="Int64" Name="geometry_set_1_point" format="ascii" RangeMin="0" RangeMax="1">
+        <DataArray type="Int64" Name="geometry_set_1_line" format="ascii" RangeMin="0" RangeMax="1">
           1 0 0 0 0 0
           0 1 0 0 0 0
           0 0 1 0 0 0
@@ -70,7 +70,7 @@
           0 0 0 0 0 1
           0 0 0 0 0 0
         </DataArray>
-        <DataArray type="Int64" Name="geometry_set_2_point" format="ascii" RangeMin="0" RangeMax="1">
+        <DataArray type="Int64" Name="geometry_set_2_line" format="ascii" RangeMin="0" RangeMax="1">
           0 0 0 0 0 0
           1 0 0 0 0 0
           0 1 0 0 0 0
@@ -79,7 +79,7 @@
           0 0 0 0 1 0
           0 0 0 0 0 1
         </DataArray>
-        <DataArray type="Int64" Name="geometry_set_3_point" format="ascii" RangeMin="0" RangeMax="1">
+        <DataArray type="Int64" Name="geometry_set_3_line" format="ascii" RangeMin="0" RangeMax="1">
           1 1 1 1 1 1
           1 0 0 0 0 0
           0 0 0 0 0 0

--- a/tests/reference-files/test_integration_space_time_varying_material_length_linear_arc_length.vtu
+++ b/tests/reference-files/test_integration_space_time_varying_material_length_linear_arc_length.vtu
@@ -61,7 +61,7 @@
           7.210000000000001 7.210000000000001 7.210000000000001 7.210000000000001 7.210000000000001 8.59
           8.59 8.59 8.59 8.59 8.59 8.59
         </DataArray>
-        <DataArray type="Int64" Name="geometry_set_0_point" format="ascii" RangeMin="0" RangeMax="1">
+        <DataArray type="Int64" Name="geometry_set_0_line" format="ascii" RangeMin="0" RangeMax="1">
           0 0 0 0 0 0
           0 0 0 0 0 0
           0 0 0 0 0 0
@@ -70,7 +70,7 @@
           0 0 0 0 0 1
           1 1 1 1 1 1
         </DataArray>
-        <DataArray type="Int64" Name="geometry_set_1_point" format="ascii" RangeMin="0" RangeMax="1">
+        <DataArray type="Int64" Name="geometry_set_1_line" format="ascii" RangeMin="0" RangeMax="1">
           1 0 0 0 0 0
           0 1 0 0 0 0
           0 0 1 0 0 0
@@ -79,7 +79,7 @@
           0 0 0 0 0 1
           0 0 0 0 0 0
         </DataArray>
-        <DataArray type="Int64" Name="geometry_set_2_point" format="ascii" RangeMin="0" RangeMax="1">
+        <DataArray type="Int64" Name="geometry_set_2_line" format="ascii" RangeMin="0" RangeMax="1">
           0 0 0 0 0 0
           1 0 0 0 0 0
           0 1 0 0 0 0
@@ -88,7 +88,7 @@
           0 0 0 0 1 0
           0 0 0 0 0 1
         </DataArray>
-        <DataArray type="Int64" Name="geometry_set_3_point" format="ascii" RangeMin="0" RangeMax="1">
+        <DataArray type="Int64" Name="geometry_set_3_line" format="ascii" RangeMin="0" RangeMax="1">
           1 1 1 1 1 1
           1 0 0 0 0 0
           0 0 0 0 0 0

--- a/tests/reference-files/test_integration_space_time_varying_material_length_linear_coupling.vtu
+++ b/tests/reference-files/test_integration_space_time_varying_material_length_linear_coupling.vtu
@@ -48,84 +48,84 @@
           8.59 8.59 8.59 8.59 8.59 8.59
         </DataArray>
         <DataArray type="Int64" Name="geometry_set_0_point" format="ascii" RangeMin="0" RangeMax="1">
+          0 0 0 1 0 0
           0 0 0 0 0 0
           0 0 0 0 0 0
           0 0 0 0 0 0
           0 0 0 0 0 0
           0 0 0 0 0 0
-          1 1 1 1 1 1
         </DataArray>
         <DataArray type="Int64" Name="geometry_set_1_point" format="ascii" RangeMin="0" RangeMax="1">
-          1 0 0 0 0 0
-          1 0 0 0 0 0
-          1 0 0 0 0 0
-          1 0 0 0 0 0
-          1 0 0 0 0 0
-          1 0 0 0 0 0
+          0 0 0 0 0 0
+          0 0 0 1 0 0
+          0 0 0 0 0 0
+          0 0 0 0 0 0
+          0 0 0 0 0 0
+          0 0 0 0 0 0
         </DataArray>
         <DataArray type="Int64" Name="geometry_set_2_point" format="ascii" RangeMin="0" RangeMax="1">
-          0 0 0 0 0 1
-          0 0 0 0 0 1
-          0 0 0 0 0 1
-          0 0 0 0 0 1
-          0 0 0 0 0 1
-          0 0 0 0 0 1
+          0 0 0 0 0 0
+          0 0 0 0 0 0
+          0 0 0 1 0 0
+          0 0 0 0 0 0
+          0 0 0 0 0 0
+          0 0 0 0 0 0
         </DataArray>
         <DataArray type="Int64" Name="geometry_set_3_point" format="ascii" RangeMin="0" RangeMax="1">
-          1 1 1 1 1 1
           0 0 0 0 0 0
           0 0 0 0 0 0
           0 0 0 0 0 0
+          0 0 0 1 0 0
           0 0 0 0 0 0
           0 0 0 0 0 0
         </DataArray>
         <DataArray type="Int64" Name="geometry_set_4_point" format="ascii" RangeMin="0" RangeMax="1">
+          0 0 0 0 0 0
+          0 0 0 0 0 0
+          0 0 0 0 0 0
+          0 0 0 0 0 0
           0 0 0 1 0 0
-          0 0 0 0 0 0
-          0 0 0 0 0 0
-          0 0 0 0 0 0
-          0 0 0 0 0 0
           0 0 0 0 0 0
         </DataArray>
         <DataArray type="Int64" Name="geometry_set_5_point" format="ascii" RangeMin="0" RangeMax="1">
           0 0 0 0 0 0
+          0 0 0 0 0 0
+          0 0 0 0 0 0
+          0 0 0 0 0 0
+          0 0 0 0 0 0
           0 0 0 1 0 0
-          0 0 0 0 0 0
-          0 0 0 0 0 0
-          0 0 0 0 0 0
-          0 0 0 0 0 0
         </DataArray>
-        <DataArray type="Int64" Name="geometry_set_6_point" format="ascii" RangeMin="0" RangeMax="1">
-          0 0 0 0 0 0
-          0 0 0 0 0 0
-          0 0 0 1 0 0
+        <DataArray type="Int64" Name="geometry_set_6_line" format="ascii" RangeMin="0" RangeMax="1">
           0 0 0 0 0 0
           0 0 0 0 0 0
           0 0 0 0 0 0
+          0 0 0 0 0 0
+          0 0 0 0 0 0
+          1 1 1 1 1 1
         </DataArray>
-        <DataArray type="Int64" Name="geometry_set_7_point" format="ascii" RangeMin="0" RangeMax="1">
-          0 0 0 0 0 0
-          0 0 0 0 0 0
-          0 0 0 0 0 0
-          0 0 0 1 0 0
-          0 0 0 0 0 0
-          0 0 0 0 0 0
+        <DataArray type="Int64" Name="geometry_set_7_line" format="ascii" RangeMin="0" RangeMax="1">
+          1 0 0 0 0 0
+          1 0 0 0 0 0
+          1 0 0 0 0 0
+          1 0 0 0 0 0
+          1 0 0 0 0 0
+          1 0 0 0 0 0
         </DataArray>
-        <DataArray type="Int64" Name="geometry_set_8_point" format="ascii" RangeMin="0" RangeMax="1">
-          0 0 0 0 0 0
-          0 0 0 0 0 0
-          0 0 0 0 0 0
-          0 0 0 0 0 0
-          0 0 0 1 0 0
-          0 0 0 0 0 0
+        <DataArray type="Int64" Name="geometry_set_8_line" format="ascii" RangeMin="0" RangeMax="1">
+          0 0 0 0 0 1
+          0 0 0 0 0 1
+          0 0 0 0 0 1
+          0 0 0 0 0 1
+          0 0 0 0 0 1
+          0 0 0 0 0 1
         </DataArray>
-        <DataArray type="Int64" Name="geometry_set_9_point" format="ascii" RangeMin="0" RangeMax="1">
+        <DataArray type="Int64" Name="geometry_set_9_line" format="ascii" RangeMin="0" RangeMax="1">
+          1 1 1 1 1 1
           0 0 0 0 0 0
           0 0 0 0 0 0
           0 0 0 0 0 0
           0 0 0 0 0 0
           0 0 0 0 0 0
-          0 0 0 1 0 0
         </DataArray>
         <DataArray type="Int64" Name="geometry_set_10_surface" format="ascii" RangeMin="1" RangeMax="1">
           1 1 1 1 1 1

--- a/tests/reference-files/test_integration_space_time_varying_material_length_linear_coupling_arc_length.vtu
+++ b/tests/reference-files/test_integration_space_time_varying_material_length_linear_coupling_arc_length.vtu
@@ -56,84 +56,84 @@
           8.59 8.59 8.59 8.59 8.59 8.59
         </DataArray>
         <DataArray type="Int64" Name="geometry_set_0_point" format="ascii" RangeMin="0" RangeMax="1">
+          0 0 0 1 0 0
           0 0 0 0 0 0
           0 0 0 0 0 0
           0 0 0 0 0 0
           0 0 0 0 0 0
           0 0 0 0 0 0
-          1 1 1 1 1 1
         </DataArray>
         <DataArray type="Int64" Name="geometry_set_1_point" format="ascii" RangeMin="0" RangeMax="1">
-          1 0 0 0 0 0
-          1 0 0 0 0 0
-          1 0 0 0 0 0
-          1 0 0 0 0 0
-          1 0 0 0 0 0
-          1 0 0 0 0 0
+          0 0 0 0 0 0
+          0 0 0 1 0 0
+          0 0 0 0 0 0
+          0 0 0 0 0 0
+          0 0 0 0 0 0
+          0 0 0 0 0 0
         </DataArray>
         <DataArray type="Int64" Name="geometry_set_2_point" format="ascii" RangeMin="0" RangeMax="1">
-          0 0 0 0 0 1
-          0 0 0 0 0 1
-          0 0 0 0 0 1
-          0 0 0 0 0 1
-          0 0 0 0 0 1
-          0 0 0 0 0 1
+          0 0 0 0 0 0
+          0 0 0 0 0 0
+          0 0 0 1 0 0
+          0 0 0 0 0 0
+          0 0 0 0 0 0
+          0 0 0 0 0 0
         </DataArray>
         <DataArray type="Int64" Name="geometry_set_3_point" format="ascii" RangeMin="0" RangeMax="1">
-          1 1 1 1 1 1
           0 0 0 0 0 0
           0 0 0 0 0 0
           0 0 0 0 0 0
+          0 0 0 1 0 0
           0 0 0 0 0 0
           0 0 0 0 0 0
         </DataArray>
         <DataArray type="Int64" Name="geometry_set_4_point" format="ascii" RangeMin="0" RangeMax="1">
+          0 0 0 0 0 0
+          0 0 0 0 0 0
+          0 0 0 0 0 0
+          0 0 0 0 0 0
           0 0 0 1 0 0
-          0 0 0 0 0 0
-          0 0 0 0 0 0
-          0 0 0 0 0 0
-          0 0 0 0 0 0
           0 0 0 0 0 0
         </DataArray>
         <DataArray type="Int64" Name="geometry_set_5_point" format="ascii" RangeMin="0" RangeMax="1">
           0 0 0 0 0 0
+          0 0 0 0 0 0
+          0 0 0 0 0 0
+          0 0 0 0 0 0
+          0 0 0 0 0 0
           0 0 0 1 0 0
-          0 0 0 0 0 0
-          0 0 0 0 0 0
-          0 0 0 0 0 0
-          0 0 0 0 0 0
         </DataArray>
-        <DataArray type="Int64" Name="geometry_set_6_point" format="ascii" RangeMin="0" RangeMax="1">
-          0 0 0 0 0 0
-          0 0 0 0 0 0
-          0 0 0 1 0 0
+        <DataArray type="Int64" Name="geometry_set_6_line" format="ascii" RangeMin="0" RangeMax="1">
           0 0 0 0 0 0
           0 0 0 0 0 0
           0 0 0 0 0 0
+          0 0 0 0 0 0
+          0 0 0 0 0 0
+          1 1 1 1 1 1
         </DataArray>
-        <DataArray type="Int64" Name="geometry_set_7_point" format="ascii" RangeMin="0" RangeMax="1">
-          0 0 0 0 0 0
-          0 0 0 0 0 0
-          0 0 0 0 0 0
-          0 0 0 1 0 0
-          0 0 0 0 0 0
-          0 0 0 0 0 0
+        <DataArray type="Int64" Name="geometry_set_7_line" format="ascii" RangeMin="0" RangeMax="1">
+          1 0 0 0 0 0
+          1 0 0 0 0 0
+          1 0 0 0 0 0
+          1 0 0 0 0 0
+          1 0 0 0 0 0
+          1 0 0 0 0 0
         </DataArray>
-        <DataArray type="Int64" Name="geometry_set_8_point" format="ascii" RangeMin="0" RangeMax="1">
-          0 0 0 0 0 0
-          0 0 0 0 0 0
-          0 0 0 0 0 0
-          0 0 0 0 0 0
-          0 0 0 1 0 0
-          0 0 0 0 0 0
+        <DataArray type="Int64" Name="geometry_set_8_line" format="ascii" RangeMin="0" RangeMax="1">
+          0 0 0 0 0 1
+          0 0 0 0 0 1
+          0 0 0 0 0 1
+          0 0 0 0 0 1
+          0 0 0 0 0 1
+          0 0 0 0 0 1
         </DataArray>
-        <DataArray type="Int64" Name="geometry_set_9_point" format="ascii" RangeMin="0" RangeMax="1">
+        <DataArray type="Int64" Name="geometry_set_9_line" format="ascii" RangeMin="0" RangeMax="1">
+          1 1 1 1 1 1
           0 0 0 0 0 0
           0 0 0 0 0 0
           0 0 0 0 0 0
           0 0 0 0 0 0
           0 0 0 0 0 0
-          0 0 0 1 0 0
         </DataArray>
         <DataArray type="Int64" Name="geometry_set_10_surface" format="ascii" RangeMin="1" RangeMax="1">
           1 1 1 1 1 1

--- a/tests/reference-files/test_integration_space_time_varying_material_length_quadratic.vtu
+++ b/tests/reference-files/test_integration_space_time_varying_material_length_quadratic.vtu
@@ -127,7 +127,7 @@
           8.59 8.59 8.59 8.59 8.59 8.59
           8.59 8.59 8.59 8.59 8.59 8.59
         </DataArray>
-        <DataArray type="Int64" Name="geometry_set_0_point" format="ascii" RangeMin="0" RangeMax="1">
+        <DataArray type="Int64" Name="geometry_set_0_line" format="ascii" RangeMin="0" RangeMax="1">
           0 0 0 0 0 0
           0 0 0 0 0 0
           0 0 0 0 0 0
@@ -151,7 +151,7 @@
           1 1 1 1 1 1
           1 1 1 1 1 1
         </DataArray>
-        <DataArray type="Int64" Name="geometry_set_1_point" format="ascii" RangeMin="0" RangeMax="1">
+        <DataArray type="Int64" Name="geometry_set_1_line" format="ascii" RangeMin="0" RangeMax="1">
           1 0 0 0 0 0
           0 0 0 0 0 0
           1 0 0 0 0 0
@@ -175,7 +175,7 @@
           1 0 0 0 0 0
           0 0 0 0 0 0
         </DataArray>
-        <DataArray type="Int64" Name="geometry_set_2_point" format="ascii" RangeMin="0" RangeMax="1">
+        <DataArray type="Int64" Name="geometry_set_2_line" format="ascii" RangeMin="0" RangeMax="1">
           0 0 0 0 0 0
           0 0 0 0 0 1
           0 0 0 0 0 0
@@ -199,7 +199,7 @@
           0 0 0 0 0 0
           0 0 0 0 0 1
         </DataArray>
-        <DataArray type="Int64" Name="geometry_set_3_point" format="ascii" RangeMin="0" RangeMax="1">
+        <DataArray type="Int64" Name="geometry_set_3_line" format="ascii" RangeMin="0" RangeMax="1">
           1 1 1 1 1 1
           1 1 1 1 1 1
           0 0 0 0 0 0

--- a/tests/reference-files/test_integration_space_time_varying_material_length_quadratic_arc_length.vtu
+++ b/tests/reference-files/test_integration_space_time_varying_material_length_quadratic_arc_length.vtu
@@ -151,7 +151,7 @@
           8.59 8.59 8.59 8.59 8.59 8.59
           8.59 8.59 8.59 8.59 8.59 8.59
         </DataArray>
-        <DataArray type="Int64" Name="geometry_set_0_point" format="ascii" RangeMin="0" RangeMax="1">
+        <DataArray type="Int64" Name="geometry_set_0_line" format="ascii" RangeMin="0" RangeMax="1">
           0 0 0 0 0 0
           0 0 0 0 0 0
           0 0 0 0 0 0
@@ -175,7 +175,7 @@
           1 1 1 1 1 1
           1 1 1 1 1 1
         </DataArray>
-        <DataArray type="Int64" Name="geometry_set_1_point" format="ascii" RangeMin="0" RangeMax="1">
+        <DataArray type="Int64" Name="geometry_set_1_line" format="ascii" RangeMin="0" RangeMax="1">
           1 0 0 0 0 0
           0 0 0 0 0 0
           1 0 0 0 0 0
@@ -199,7 +199,7 @@
           1 0 0 0 0 0
           0 0 0 0 0 0
         </DataArray>
-        <DataArray type="Int64" Name="geometry_set_2_point" format="ascii" RangeMin="0" RangeMax="1">
+        <DataArray type="Int64" Name="geometry_set_2_line" format="ascii" RangeMin="0" RangeMax="1">
           0 0 0 0 0 0
           0 0 0 0 0 1
           0 0 0 0 0 0
@@ -223,7 +223,7 @@
           0 0 0 0 0 0
           0 0 0 0 0 1
         </DataArray>
-        <DataArray type="Int64" Name="geometry_set_3_point" format="ascii" RangeMin="0" RangeMax="1">
+        <DataArray type="Int64" Name="geometry_set_3_line" format="ascii" RangeMin="0" RangeMax="1">
           1 1 1 1 1 1
           1 1 1 1 1 1
           0 0 0 0 0 0

--- a/tests/reference-files/test_integration_space_time_varying_material_length_quadratic_coupling.vtu
+++ b/tests/reference-files/test_integration_space_time_varying_material_length_quadratic_coupling.vtu
@@ -122,6 +122,259 @@
         </DataArray>
         <DataArray type="Int64" Name="geometry_set_0_point" format="ascii" RangeMin="0" RangeMax="1">
           0 0 0 0 0 0
+          1 0 0 0 0 0
+          0 0 0 0 0 0
+          0 0 0 0 0 0
+          0 0 0 0 0 0
+          0 0 0 0 0 0
+          0 0 0 0 0 0
+          0 0 0 0 0 0
+          0 0 0 0 0 0
+          0 0 0 0 0 0
+          0 0 0 0 0 0
+          0 0 0 0 0 0
+          0 0 0 0 0 0
+          0 0 0 0 0 0
+          0 0 0 0 0 0
+          0 0 0 0 0 0
+          0 0 0 0 0 0
+          0 0 0 0 0 0
+          0 0 0 0 0 0
+          0 0 0 0 0 0
+          0
+        </DataArray>
+        <DataArray type="Int64" Name="geometry_set_1_point" format="ascii" RangeMin="0" RangeMax="1">
+          0 0 0 0 0 0
+          0 0 0 0 0 0
+          0 0 0 0 0 1
+          0 0 0 0 0 0
+          0 0 0 0 0 0
+          0 0 0 0 0 0
+          0 0 0 0 0 0
+          0 0 0 0 0 0
+          0 0 0 0 0 0
+          0 0 0 0 0 0
+          0 0 0 0 0 0
+          0 0 0 0 0 0
+          0 0 0 0 0 0
+          0 0 0 0 0 0
+          0 0 0 0 0 0
+          0 0 0 0 0 0
+          0 0 0 0 0 0
+          0 0 0 0 0 0
+          0 0 0 0 0 0
+          0 0 0 0 0 0
+          0
+        </DataArray>
+        <DataArray type="Int64" Name="geometry_set_2_point" format="ascii" RangeMin="0" RangeMax="1">
+          0 0 0 0 0 0
+          0 0 0 0 0 0
+          0 0 0 0 0 0
+          0 0 0 0 0 0
+          0 0 0 0 1 0
+          0 0 0 0 0 0
+          0 0 0 0 0 0
+          0 0 0 0 0 0
+          0 0 0 0 0 0
+          0 0 0 0 0 0
+          0 0 0 0 0 0
+          0 0 0 0 0 0
+          0 0 0 0 0 0
+          0 0 0 0 0 0
+          0 0 0 0 0 0
+          0 0 0 0 0 0
+          0 0 0 0 0 0
+          0 0 0 0 0 0
+          0 0 0 0 0 0
+          0 0 0 0 0 0
+          0
+        </DataArray>
+        <DataArray type="Int64" Name="geometry_set_3_point" format="ascii" RangeMin="0" RangeMax="1">
+          0 0 0 0 0 0
+          0 0 0 0 0 0
+          0 0 0 0 0 0
+          0 0 0 0 0 0
+          0 0 0 0 0 0
+          0 0 0 0 0 0
+          0 0 0 1 0 0
+          0 0 0 0 0 0
+          0 0 0 0 0 0
+          0 0 0 0 0 0
+          0 0 0 0 0 0
+          0 0 0 0 0 0
+          0 0 0 0 0 0
+          0 0 0 0 0 0
+          0 0 0 0 0 0
+          0 0 0 0 0 0
+          0 0 0 0 0 0
+          0 0 0 0 0 0
+          0 0 0 0 0 0
+          0 0 0 0 0 0
+          0
+        </DataArray>
+        <DataArray type="Int64" Name="geometry_set_4_point" format="ascii" RangeMin="0" RangeMax="1">
+          0 0 0 0 0 0
+          0 0 0 0 0 0
+          0 0 0 0 0 0
+          0 0 0 0 0 0
+          0 0 0 0 0 0
+          0 0 0 0 0 0
+          0 0 0 0 0 0
+          0 0 0 0 0 0
+          0 0 1 0 0 0
+          0 0 0 0 0 0
+          0 0 0 0 0 0
+          0 0 0 0 0 0
+          0 0 0 0 0 0
+          0 0 0 0 0 0
+          0 0 0 0 0 0
+          0 0 0 0 0 0
+          0 0 0 0 0 0
+          0 0 0 0 0 0
+          0 0 0 0 0 0
+          0 0 0 0 0 0
+          0
+        </DataArray>
+        <DataArray type="Int64" Name="geometry_set_5_point" format="ascii" RangeMin="0" RangeMax="1">
+          0 0 0 0 0 0
+          0 0 0 0 0 0
+          0 0 0 0 0 0
+          0 0 0 0 0 0
+          0 0 0 0 0 0
+          0 0 0 0 0 0
+          0 0 0 0 0 0
+          0 0 0 0 0 0
+          0 0 0 0 0 0
+          0 0 0 0 0 0
+          0 1 0 0 0 0
+          0 0 0 0 0 0
+          0 0 0 0 0 0
+          0 0 0 0 0 0
+          0 0 0 0 0 0
+          0 0 0 0 0 0
+          0 0 0 0 0 0
+          0 0 0 0 0 0
+          0 0 0 0 0 0
+          0 0 0 0 0 0
+          0
+        </DataArray>
+        <DataArray type="Int64" Name="geometry_set_6_point" format="ascii" RangeMin="0" RangeMax="1">
+          0 0 0 0 0 0
+          0 0 0 0 0 0
+          0 0 0 0 0 0
+          0 0 0 0 0 0
+          0 0 0 0 0 0
+          0 0 0 0 0 0
+          0 0 0 0 0 0
+          0 0 0 0 0 0
+          0 0 0 0 0 0
+          0 0 0 0 0 0
+          0 0 0 0 0 0
+          0 0 0 0 0 0
+          1 0 0 0 0 0
+          0 0 0 0 0 0
+          0 0 0 0 0 0
+          0 0 0 0 0 0
+          0 0 0 0 0 0
+          0 0 0 0 0 0
+          0 0 0 0 0 0
+          0 0 0 0 0 0
+          0
+        </DataArray>
+        <DataArray type="Int64" Name="geometry_set_7_point" format="ascii" RangeMin="0" RangeMax="1">
+          0 0 0 0 0 0
+          0 0 0 0 0 0
+          0 0 0 0 0 0
+          0 0 0 0 0 0
+          0 0 0 0 0 0
+          0 0 0 0 0 0
+          0 0 0 0 0 0
+          0 0 0 0 0 0
+          0 0 0 0 0 0
+          0 0 0 0 0 0
+          0 0 0 0 0 0
+          0 0 0 0 0 0
+          0 0 0 0 0 0
+          0 0 0 0 0 1
+          0 0 0 0 0 0
+          0 0 0 0 0 0
+          0 0 0 0 0 0
+          0 0 0 0 0 0
+          0 0 0 0 0 0
+          0 0 0 0 0 0
+          0
+        </DataArray>
+        <DataArray type="Int64" Name="geometry_set_8_point" format="ascii" RangeMin="0" RangeMax="1">
+          0 0 0 0 0 0
+          0 0 0 0 0 0
+          0 0 0 0 0 0
+          0 0 0 0 0 0
+          0 0 0 0 0 0
+          0 0 0 0 0 0
+          0 0 0 0 0 0
+          0 0 0 0 0 0
+          0 0 0 0 0 0
+          0 0 0 0 0 0
+          0 0 0 0 0 0
+          0 0 0 0 0 0
+          0 0 0 0 0 0
+          0 0 0 0 0 0
+          0 0 0 0 0 0
+          0 0 0 0 1 0
+          0 0 0 0 0 0
+          0 0 0 0 0 0
+          0 0 0 0 0 0
+          0 0 0 0 0 0
+          0
+        </DataArray>
+        <DataArray type="Int64" Name="geometry_set_9_point" format="ascii" RangeMin="0" RangeMax="1">
+          0 0 0 0 0 0
+          0 0 0 0 0 0
+          0 0 0 0 0 0
+          0 0 0 0 0 0
+          0 0 0 0 0 0
+          0 0 0 0 0 0
+          0 0 0 0 0 0
+          0 0 0 0 0 0
+          0 0 0 0 0 0
+          0 0 0 0 0 0
+          0 0 0 0 0 0
+          0 0 0 0 0 0
+          0 0 0 0 0 0
+          0 0 0 0 0 0
+          0 0 0 0 0 0
+          0 0 0 0 0 0
+          0 0 0 0 0 0
+          0 0 0 1 0 0
+          0 0 0 0 0 0
+          0 0 0 0 0 0
+          0
+        </DataArray>
+        <DataArray type="Int64" Name="geometry_set_10_point" format="ascii" RangeMin="0" RangeMax="1">
+          0 0 0 0 0 0
+          0 0 0 0 0 0
+          0 0 0 0 0 0
+          0 0 0 0 0 0
+          0 0 0 0 0 0
+          0 0 0 0 0 0
+          0 0 0 0 0 0
+          0 0 0 0 0 0
+          0 0 0 0 0 0
+          0 0 0 0 0 0
+          0 0 0 0 0 0
+          0 0 0 0 0 0
+          0 0 0 0 0 0
+          0 0 0 0 0 0
+          0 0 0 0 0 0
+          0 0 0 0 0 0
+          0 0 0 0 0 0
+          0 0 0 0 0 0
+          0 0 0 0 0 0
+          0 0 1 0 0 0
+          0
+        </DataArray>
+        <DataArray type="Int64" Name="geometry_set_11_line" format="ascii" RangeMin="0" RangeMax="1">
+          0 0 0 0 0 0
           0 0 0 0 0 0
           0 0 0 0 0 0
           0 0 0 0 0 0
@@ -143,7 +396,7 @@
           1 1 1 1 1 1
           1
         </DataArray>
-        <DataArray type="Int64" Name="geometry_set_1_point" format="ascii" RangeMin="0" RangeMax="1">
+        <DataArray type="Int64" Name="geometry_set_12_line" format="ascii" RangeMin="0" RangeMax="1">
           1 0 0 0 0 0
           0 0 0 0 0 1
           0 0 0 0 0 0
@@ -166,7 +419,7 @@
           0 0 0 0 0 0
           0
         </DataArray>
-        <DataArray type="Int64" Name="geometry_set_2_point" format="ascii" RangeMin="0" RangeMax="1">
+        <DataArray type="Int64" Name="geometry_set_13_line" format="ascii" RangeMin="0" RangeMax="1">
           0 0 0 0 0 0
           0 0 0 0 1 0
           0 0 0 0 0 0
@@ -189,7 +442,7 @@
           0 0 0 0 0 0
           1
         </DataArray>
-        <DataArray type="Int64" Name="geometry_set_3_point" format="ascii" RangeMin="0" RangeMax="1">
+        <DataArray type="Int64" Name="geometry_set_14_line" format="ascii" RangeMin="0" RangeMax="1">
           1 1 1 1 1 1
           1 1 1 1 1 0
           0 0 0 0 0 0
@@ -210,259 +463,6 @@
           0 0 0 0 0 0
           0 0 0 0 0 0
           0 0 0 0 0 0
-          0
-        </DataArray>
-        <DataArray type="Int64" Name="geometry_set_4_point" format="ascii" RangeMin="0" RangeMax="1">
-          0 0 0 0 0 0
-          1 0 0 0 0 0
-          0 0 0 0 0 0
-          0 0 0 0 0 0
-          0 0 0 0 0 0
-          0 0 0 0 0 0
-          0 0 0 0 0 0
-          0 0 0 0 0 0
-          0 0 0 0 0 0
-          0 0 0 0 0 0
-          0 0 0 0 0 0
-          0 0 0 0 0 0
-          0 0 0 0 0 0
-          0 0 0 0 0 0
-          0 0 0 0 0 0
-          0 0 0 0 0 0
-          0 0 0 0 0 0
-          0 0 0 0 0 0
-          0 0 0 0 0 0
-          0 0 0 0 0 0
-          0
-        </DataArray>
-        <DataArray type="Int64" Name="geometry_set_5_point" format="ascii" RangeMin="0" RangeMax="1">
-          0 0 0 0 0 0
-          0 0 0 0 0 0
-          0 0 0 0 0 1
-          0 0 0 0 0 0
-          0 0 0 0 0 0
-          0 0 0 0 0 0
-          0 0 0 0 0 0
-          0 0 0 0 0 0
-          0 0 0 0 0 0
-          0 0 0 0 0 0
-          0 0 0 0 0 0
-          0 0 0 0 0 0
-          0 0 0 0 0 0
-          0 0 0 0 0 0
-          0 0 0 0 0 0
-          0 0 0 0 0 0
-          0 0 0 0 0 0
-          0 0 0 0 0 0
-          0 0 0 0 0 0
-          0 0 0 0 0 0
-          0
-        </DataArray>
-        <DataArray type="Int64" Name="geometry_set_6_point" format="ascii" RangeMin="0" RangeMax="1">
-          0 0 0 0 0 0
-          0 0 0 0 0 0
-          0 0 0 0 0 0
-          0 0 0 0 0 0
-          0 0 0 0 1 0
-          0 0 0 0 0 0
-          0 0 0 0 0 0
-          0 0 0 0 0 0
-          0 0 0 0 0 0
-          0 0 0 0 0 0
-          0 0 0 0 0 0
-          0 0 0 0 0 0
-          0 0 0 0 0 0
-          0 0 0 0 0 0
-          0 0 0 0 0 0
-          0 0 0 0 0 0
-          0 0 0 0 0 0
-          0 0 0 0 0 0
-          0 0 0 0 0 0
-          0 0 0 0 0 0
-          0
-        </DataArray>
-        <DataArray type="Int64" Name="geometry_set_7_point" format="ascii" RangeMin="0" RangeMax="1">
-          0 0 0 0 0 0
-          0 0 0 0 0 0
-          0 0 0 0 0 0
-          0 0 0 0 0 0
-          0 0 0 0 0 0
-          0 0 0 0 0 0
-          0 0 0 1 0 0
-          0 0 0 0 0 0
-          0 0 0 0 0 0
-          0 0 0 0 0 0
-          0 0 0 0 0 0
-          0 0 0 0 0 0
-          0 0 0 0 0 0
-          0 0 0 0 0 0
-          0 0 0 0 0 0
-          0 0 0 0 0 0
-          0 0 0 0 0 0
-          0 0 0 0 0 0
-          0 0 0 0 0 0
-          0 0 0 0 0 0
-          0
-        </DataArray>
-        <DataArray type="Int64" Name="geometry_set_8_point" format="ascii" RangeMin="0" RangeMax="1">
-          0 0 0 0 0 0
-          0 0 0 0 0 0
-          0 0 0 0 0 0
-          0 0 0 0 0 0
-          0 0 0 0 0 0
-          0 0 0 0 0 0
-          0 0 0 0 0 0
-          0 0 0 0 0 0
-          0 0 1 0 0 0
-          0 0 0 0 0 0
-          0 0 0 0 0 0
-          0 0 0 0 0 0
-          0 0 0 0 0 0
-          0 0 0 0 0 0
-          0 0 0 0 0 0
-          0 0 0 0 0 0
-          0 0 0 0 0 0
-          0 0 0 0 0 0
-          0 0 0 0 0 0
-          0 0 0 0 0 0
-          0
-        </DataArray>
-        <DataArray type="Int64" Name="geometry_set_9_point" format="ascii" RangeMin="0" RangeMax="1">
-          0 0 0 0 0 0
-          0 0 0 0 0 0
-          0 0 0 0 0 0
-          0 0 0 0 0 0
-          0 0 0 0 0 0
-          0 0 0 0 0 0
-          0 0 0 0 0 0
-          0 0 0 0 0 0
-          0 0 0 0 0 0
-          0 0 0 0 0 0
-          0 1 0 0 0 0
-          0 0 0 0 0 0
-          0 0 0 0 0 0
-          0 0 0 0 0 0
-          0 0 0 0 0 0
-          0 0 0 0 0 0
-          0 0 0 0 0 0
-          0 0 0 0 0 0
-          0 0 0 0 0 0
-          0 0 0 0 0 0
-          0
-        </DataArray>
-        <DataArray type="Int64" Name="geometry_set_10_point" format="ascii" RangeMin="0" RangeMax="1">
-          0 0 0 0 0 0
-          0 0 0 0 0 0
-          0 0 0 0 0 0
-          0 0 0 0 0 0
-          0 0 0 0 0 0
-          0 0 0 0 0 0
-          0 0 0 0 0 0
-          0 0 0 0 0 0
-          0 0 0 0 0 0
-          0 0 0 0 0 0
-          0 0 0 0 0 0
-          0 0 0 0 0 0
-          1 0 0 0 0 0
-          0 0 0 0 0 0
-          0 0 0 0 0 0
-          0 0 0 0 0 0
-          0 0 0 0 0 0
-          0 0 0 0 0 0
-          0 0 0 0 0 0
-          0 0 0 0 0 0
-          0
-        </DataArray>
-        <DataArray type="Int64" Name="geometry_set_11_point" format="ascii" RangeMin="0" RangeMax="1">
-          0 0 0 0 0 0
-          0 0 0 0 0 0
-          0 0 0 0 0 0
-          0 0 0 0 0 0
-          0 0 0 0 0 0
-          0 0 0 0 0 0
-          0 0 0 0 0 0
-          0 0 0 0 0 0
-          0 0 0 0 0 0
-          0 0 0 0 0 0
-          0 0 0 0 0 0
-          0 0 0 0 0 0
-          0 0 0 0 0 0
-          0 0 0 0 0 1
-          0 0 0 0 0 0
-          0 0 0 0 0 0
-          0 0 0 0 0 0
-          0 0 0 0 0 0
-          0 0 0 0 0 0
-          0 0 0 0 0 0
-          0
-        </DataArray>
-        <DataArray type="Int64" Name="geometry_set_12_point" format="ascii" RangeMin="0" RangeMax="1">
-          0 0 0 0 0 0
-          0 0 0 0 0 0
-          0 0 0 0 0 0
-          0 0 0 0 0 0
-          0 0 0 0 0 0
-          0 0 0 0 0 0
-          0 0 0 0 0 0
-          0 0 0 0 0 0
-          0 0 0 0 0 0
-          0 0 0 0 0 0
-          0 0 0 0 0 0
-          0 0 0 0 0 0
-          0 0 0 0 0 0
-          0 0 0 0 0 0
-          0 0 0 0 0 0
-          0 0 0 0 1 0
-          0 0 0 0 0 0
-          0 0 0 0 0 0
-          0 0 0 0 0 0
-          0 0 0 0 0 0
-          0
-        </DataArray>
-        <DataArray type="Int64" Name="geometry_set_13_point" format="ascii" RangeMin="0" RangeMax="1">
-          0 0 0 0 0 0
-          0 0 0 0 0 0
-          0 0 0 0 0 0
-          0 0 0 0 0 0
-          0 0 0 0 0 0
-          0 0 0 0 0 0
-          0 0 0 0 0 0
-          0 0 0 0 0 0
-          0 0 0 0 0 0
-          0 0 0 0 0 0
-          0 0 0 0 0 0
-          0 0 0 0 0 0
-          0 0 0 0 0 0
-          0 0 0 0 0 0
-          0 0 0 0 0 0
-          0 0 0 0 0 0
-          0 0 0 0 0 0
-          0 0 0 1 0 0
-          0 0 0 0 0 0
-          0 0 0 0 0 0
-          0
-        </DataArray>
-        <DataArray type="Int64" Name="geometry_set_14_point" format="ascii" RangeMin="0" RangeMax="1">
-          0 0 0 0 0 0
-          0 0 0 0 0 0
-          0 0 0 0 0 0
-          0 0 0 0 0 0
-          0 0 0 0 0 0
-          0 0 0 0 0 0
-          0 0 0 0 0 0
-          0 0 0 0 0 0
-          0 0 0 0 0 0
-          0 0 0 0 0 0
-          0 0 0 0 0 0
-          0 0 0 0 0 0
-          0 0 0 0 0 0
-          0 0 0 0 0 0
-          0 0 0 0 0 0
-          0 0 0 0 0 0
-          0 0 0 0 0 0
-          0 0 0 0 0 0
-          0 0 0 0 0 0
-          0 0 1 0 0 0
           0
         </DataArray>
         <DataArray type="Int64" Name="geometry_set_15_surface" format="ascii" RangeMin="1" RangeMax="1">

--- a/tests/reference-files/test_integration_space_time_varying_material_length_quadratic_coupling_arc_length.vtu
+++ b/tests/reference-files/test_integration_space_time_varying_material_length_quadratic_coupling_arc_length.vtu
@@ -145,6 +145,259 @@
         </DataArray>
         <DataArray type="Int64" Name="geometry_set_0_point" format="ascii" RangeMin="0" RangeMax="1">
           0 0 0 0 0 0
+          1 0 0 0 0 0
+          0 0 0 0 0 0
+          0 0 0 0 0 0
+          0 0 0 0 0 0
+          0 0 0 0 0 0
+          0 0 0 0 0 0
+          0 0 0 0 0 0
+          0 0 0 0 0 0
+          0 0 0 0 0 0
+          0 0 0 0 0 0
+          0 0 0 0 0 0
+          0 0 0 0 0 0
+          0 0 0 0 0 0
+          0 0 0 0 0 0
+          0 0 0 0 0 0
+          0 0 0 0 0 0
+          0 0 0 0 0 0
+          0 0 0 0 0 0
+          0 0 0 0 0 0
+          0
+        </DataArray>
+        <DataArray type="Int64" Name="geometry_set_1_point" format="ascii" RangeMin="0" RangeMax="1">
+          0 0 0 0 0 0
+          0 0 0 0 0 0
+          0 0 0 0 0 1
+          0 0 0 0 0 0
+          0 0 0 0 0 0
+          0 0 0 0 0 0
+          0 0 0 0 0 0
+          0 0 0 0 0 0
+          0 0 0 0 0 0
+          0 0 0 0 0 0
+          0 0 0 0 0 0
+          0 0 0 0 0 0
+          0 0 0 0 0 0
+          0 0 0 0 0 0
+          0 0 0 0 0 0
+          0 0 0 0 0 0
+          0 0 0 0 0 0
+          0 0 0 0 0 0
+          0 0 0 0 0 0
+          0 0 0 0 0 0
+          0
+        </DataArray>
+        <DataArray type="Int64" Name="geometry_set_2_point" format="ascii" RangeMin="0" RangeMax="1">
+          0 0 0 0 0 0
+          0 0 0 0 0 0
+          0 0 0 0 0 0
+          0 0 0 0 0 0
+          0 0 0 0 1 0
+          0 0 0 0 0 0
+          0 0 0 0 0 0
+          0 0 0 0 0 0
+          0 0 0 0 0 0
+          0 0 0 0 0 0
+          0 0 0 0 0 0
+          0 0 0 0 0 0
+          0 0 0 0 0 0
+          0 0 0 0 0 0
+          0 0 0 0 0 0
+          0 0 0 0 0 0
+          0 0 0 0 0 0
+          0 0 0 0 0 0
+          0 0 0 0 0 0
+          0 0 0 0 0 0
+          0
+        </DataArray>
+        <DataArray type="Int64" Name="geometry_set_3_point" format="ascii" RangeMin="0" RangeMax="1">
+          0 0 0 0 0 0
+          0 0 0 0 0 0
+          0 0 0 0 0 0
+          0 0 0 0 0 0
+          0 0 0 0 0 0
+          0 0 0 0 0 0
+          0 0 0 1 0 0
+          0 0 0 0 0 0
+          0 0 0 0 0 0
+          0 0 0 0 0 0
+          0 0 0 0 0 0
+          0 0 0 0 0 0
+          0 0 0 0 0 0
+          0 0 0 0 0 0
+          0 0 0 0 0 0
+          0 0 0 0 0 0
+          0 0 0 0 0 0
+          0 0 0 0 0 0
+          0 0 0 0 0 0
+          0 0 0 0 0 0
+          0
+        </DataArray>
+        <DataArray type="Int64" Name="geometry_set_4_point" format="ascii" RangeMin="0" RangeMax="1">
+          0 0 0 0 0 0
+          0 0 0 0 0 0
+          0 0 0 0 0 0
+          0 0 0 0 0 0
+          0 0 0 0 0 0
+          0 0 0 0 0 0
+          0 0 0 0 0 0
+          0 0 0 0 0 0
+          0 0 1 0 0 0
+          0 0 0 0 0 0
+          0 0 0 0 0 0
+          0 0 0 0 0 0
+          0 0 0 0 0 0
+          0 0 0 0 0 0
+          0 0 0 0 0 0
+          0 0 0 0 0 0
+          0 0 0 0 0 0
+          0 0 0 0 0 0
+          0 0 0 0 0 0
+          0 0 0 0 0 0
+          0
+        </DataArray>
+        <DataArray type="Int64" Name="geometry_set_5_point" format="ascii" RangeMin="0" RangeMax="1">
+          0 0 0 0 0 0
+          0 0 0 0 0 0
+          0 0 0 0 0 0
+          0 0 0 0 0 0
+          0 0 0 0 0 0
+          0 0 0 0 0 0
+          0 0 0 0 0 0
+          0 0 0 0 0 0
+          0 0 0 0 0 0
+          0 0 0 0 0 0
+          0 1 0 0 0 0
+          0 0 0 0 0 0
+          0 0 0 0 0 0
+          0 0 0 0 0 0
+          0 0 0 0 0 0
+          0 0 0 0 0 0
+          0 0 0 0 0 0
+          0 0 0 0 0 0
+          0 0 0 0 0 0
+          0 0 0 0 0 0
+          0
+        </DataArray>
+        <DataArray type="Int64" Name="geometry_set_6_point" format="ascii" RangeMin="0" RangeMax="1">
+          0 0 0 0 0 0
+          0 0 0 0 0 0
+          0 0 0 0 0 0
+          0 0 0 0 0 0
+          0 0 0 0 0 0
+          0 0 0 0 0 0
+          0 0 0 0 0 0
+          0 0 0 0 0 0
+          0 0 0 0 0 0
+          0 0 0 0 0 0
+          0 0 0 0 0 0
+          0 0 0 0 0 0
+          1 0 0 0 0 0
+          0 0 0 0 0 0
+          0 0 0 0 0 0
+          0 0 0 0 0 0
+          0 0 0 0 0 0
+          0 0 0 0 0 0
+          0 0 0 0 0 0
+          0 0 0 0 0 0
+          0
+        </DataArray>
+        <DataArray type="Int64" Name="geometry_set_7_point" format="ascii" RangeMin="0" RangeMax="1">
+          0 0 0 0 0 0
+          0 0 0 0 0 0
+          0 0 0 0 0 0
+          0 0 0 0 0 0
+          0 0 0 0 0 0
+          0 0 0 0 0 0
+          0 0 0 0 0 0
+          0 0 0 0 0 0
+          0 0 0 0 0 0
+          0 0 0 0 0 0
+          0 0 0 0 0 0
+          0 0 0 0 0 0
+          0 0 0 0 0 0
+          0 0 0 0 0 1
+          0 0 0 0 0 0
+          0 0 0 0 0 0
+          0 0 0 0 0 0
+          0 0 0 0 0 0
+          0 0 0 0 0 0
+          0 0 0 0 0 0
+          0
+        </DataArray>
+        <DataArray type="Int64" Name="geometry_set_8_point" format="ascii" RangeMin="0" RangeMax="1">
+          0 0 0 0 0 0
+          0 0 0 0 0 0
+          0 0 0 0 0 0
+          0 0 0 0 0 0
+          0 0 0 0 0 0
+          0 0 0 0 0 0
+          0 0 0 0 0 0
+          0 0 0 0 0 0
+          0 0 0 0 0 0
+          0 0 0 0 0 0
+          0 0 0 0 0 0
+          0 0 0 0 0 0
+          0 0 0 0 0 0
+          0 0 0 0 0 0
+          0 0 0 0 0 0
+          0 0 0 0 1 0
+          0 0 0 0 0 0
+          0 0 0 0 0 0
+          0 0 0 0 0 0
+          0 0 0 0 0 0
+          0
+        </DataArray>
+        <DataArray type="Int64" Name="geometry_set_9_point" format="ascii" RangeMin="0" RangeMax="1">
+          0 0 0 0 0 0
+          0 0 0 0 0 0
+          0 0 0 0 0 0
+          0 0 0 0 0 0
+          0 0 0 0 0 0
+          0 0 0 0 0 0
+          0 0 0 0 0 0
+          0 0 0 0 0 0
+          0 0 0 0 0 0
+          0 0 0 0 0 0
+          0 0 0 0 0 0
+          0 0 0 0 0 0
+          0 0 0 0 0 0
+          0 0 0 0 0 0
+          0 0 0 0 0 0
+          0 0 0 0 0 0
+          0 0 0 0 0 0
+          0 0 0 1 0 0
+          0 0 0 0 0 0
+          0 0 0 0 0 0
+          0
+        </DataArray>
+        <DataArray type="Int64" Name="geometry_set_10_point" format="ascii" RangeMin="0" RangeMax="1">
+          0 0 0 0 0 0
+          0 0 0 0 0 0
+          0 0 0 0 0 0
+          0 0 0 0 0 0
+          0 0 0 0 0 0
+          0 0 0 0 0 0
+          0 0 0 0 0 0
+          0 0 0 0 0 0
+          0 0 0 0 0 0
+          0 0 0 0 0 0
+          0 0 0 0 0 0
+          0 0 0 0 0 0
+          0 0 0 0 0 0
+          0 0 0 0 0 0
+          0 0 0 0 0 0
+          0 0 0 0 0 0
+          0 0 0 0 0 0
+          0 0 0 0 0 0
+          0 0 0 0 0 0
+          0 0 1 0 0 0
+          0
+        </DataArray>
+        <DataArray type="Int64" Name="geometry_set_11_line" format="ascii" RangeMin="0" RangeMax="1">
+          0 0 0 0 0 0
           0 0 0 0 0 0
           0 0 0 0 0 0
           0 0 0 0 0 0
@@ -166,7 +419,7 @@
           1 1 1 1 1 1
           1
         </DataArray>
-        <DataArray type="Int64" Name="geometry_set_1_point" format="ascii" RangeMin="0" RangeMax="1">
+        <DataArray type="Int64" Name="geometry_set_12_line" format="ascii" RangeMin="0" RangeMax="1">
           1 0 0 0 0 0
           0 0 0 0 0 1
           0 0 0 0 0 0
@@ -189,7 +442,7 @@
           0 0 0 0 0 0
           0
         </DataArray>
-        <DataArray type="Int64" Name="geometry_set_2_point" format="ascii" RangeMin="0" RangeMax="1">
+        <DataArray type="Int64" Name="geometry_set_13_line" format="ascii" RangeMin="0" RangeMax="1">
           0 0 0 0 0 0
           0 0 0 0 1 0
           0 0 0 0 0 0
@@ -212,7 +465,7 @@
           0 0 0 0 0 0
           1
         </DataArray>
-        <DataArray type="Int64" Name="geometry_set_3_point" format="ascii" RangeMin="0" RangeMax="1">
+        <DataArray type="Int64" Name="geometry_set_14_line" format="ascii" RangeMin="0" RangeMax="1">
           1 1 1 1 1 1
           1 1 1 1 1 0
           0 0 0 0 0 0
@@ -233,259 +486,6 @@
           0 0 0 0 0 0
           0 0 0 0 0 0
           0 0 0 0 0 0
-          0
-        </DataArray>
-        <DataArray type="Int64" Name="geometry_set_4_point" format="ascii" RangeMin="0" RangeMax="1">
-          0 0 0 0 0 0
-          1 0 0 0 0 0
-          0 0 0 0 0 0
-          0 0 0 0 0 0
-          0 0 0 0 0 0
-          0 0 0 0 0 0
-          0 0 0 0 0 0
-          0 0 0 0 0 0
-          0 0 0 0 0 0
-          0 0 0 0 0 0
-          0 0 0 0 0 0
-          0 0 0 0 0 0
-          0 0 0 0 0 0
-          0 0 0 0 0 0
-          0 0 0 0 0 0
-          0 0 0 0 0 0
-          0 0 0 0 0 0
-          0 0 0 0 0 0
-          0 0 0 0 0 0
-          0 0 0 0 0 0
-          0
-        </DataArray>
-        <DataArray type="Int64" Name="geometry_set_5_point" format="ascii" RangeMin="0" RangeMax="1">
-          0 0 0 0 0 0
-          0 0 0 0 0 0
-          0 0 0 0 0 1
-          0 0 0 0 0 0
-          0 0 0 0 0 0
-          0 0 0 0 0 0
-          0 0 0 0 0 0
-          0 0 0 0 0 0
-          0 0 0 0 0 0
-          0 0 0 0 0 0
-          0 0 0 0 0 0
-          0 0 0 0 0 0
-          0 0 0 0 0 0
-          0 0 0 0 0 0
-          0 0 0 0 0 0
-          0 0 0 0 0 0
-          0 0 0 0 0 0
-          0 0 0 0 0 0
-          0 0 0 0 0 0
-          0 0 0 0 0 0
-          0
-        </DataArray>
-        <DataArray type="Int64" Name="geometry_set_6_point" format="ascii" RangeMin="0" RangeMax="1">
-          0 0 0 0 0 0
-          0 0 0 0 0 0
-          0 0 0 0 0 0
-          0 0 0 0 0 0
-          0 0 0 0 1 0
-          0 0 0 0 0 0
-          0 0 0 0 0 0
-          0 0 0 0 0 0
-          0 0 0 0 0 0
-          0 0 0 0 0 0
-          0 0 0 0 0 0
-          0 0 0 0 0 0
-          0 0 0 0 0 0
-          0 0 0 0 0 0
-          0 0 0 0 0 0
-          0 0 0 0 0 0
-          0 0 0 0 0 0
-          0 0 0 0 0 0
-          0 0 0 0 0 0
-          0 0 0 0 0 0
-          0
-        </DataArray>
-        <DataArray type="Int64" Name="geometry_set_7_point" format="ascii" RangeMin="0" RangeMax="1">
-          0 0 0 0 0 0
-          0 0 0 0 0 0
-          0 0 0 0 0 0
-          0 0 0 0 0 0
-          0 0 0 0 0 0
-          0 0 0 0 0 0
-          0 0 0 1 0 0
-          0 0 0 0 0 0
-          0 0 0 0 0 0
-          0 0 0 0 0 0
-          0 0 0 0 0 0
-          0 0 0 0 0 0
-          0 0 0 0 0 0
-          0 0 0 0 0 0
-          0 0 0 0 0 0
-          0 0 0 0 0 0
-          0 0 0 0 0 0
-          0 0 0 0 0 0
-          0 0 0 0 0 0
-          0 0 0 0 0 0
-          0
-        </DataArray>
-        <DataArray type="Int64" Name="geometry_set_8_point" format="ascii" RangeMin="0" RangeMax="1">
-          0 0 0 0 0 0
-          0 0 0 0 0 0
-          0 0 0 0 0 0
-          0 0 0 0 0 0
-          0 0 0 0 0 0
-          0 0 0 0 0 0
-          0 0 0 0 0 0
-          0 0 0 0 0 0
-          0 0 1 0 0 0
-          0 0 0 0 0 0
-          0 0 0 0 0 0
-          0 0 0 0 0 0
-          0 0 0 0 0 0
-          0 0 0 0 0 0
-          0 0 0 0 0 0
-          0 0 0 0 0 0
-          0 0 0 0 0 0
-          0 0 0 0 0 0
-          0 0 0 0 0 0
-          0 0 0 0 0 0
-          0
-        </DataArray>
-        <DataArray type="Int64" Name="geometry_set_9_point" format="ascii" RangeMin="0" RangeMax="1">
-          0 0 0 0 0 0
-          0 0 0 0 0 0
-          0 0 0 0 0 0
-          0 0 0 0 0 0
-          0 0 0 0 0 0
-          0 0 0 0 0 0
-          0 0 0 0 0 0
-          0 0 0 0 0 0
-          0 0 0 0 0 0
-          0 0 0 0 0 0
-          0 1 0 0 0 0
-          0 0 0 0 0 0
-          0 0 0 0 0 0
-          0 0 0 0 0 0
-          0 0 0 0 0 0
-          0 0 0 0 0 0
-          0 0 0 0 0 0
-          0 0 0 0 0 0
-          0 0 0 0 0 0
-          0 0 0 0 0 0
-          0
-        </DataArray>
-        <DataArray type="Int64" Name="geometry_set_10_point" format="ascii" RangeMin="0" RangeMax="1">
-          0 0 0 0 0 0
-          0 0 0 0 0 0
-          0 0 0 0 0 0
-          0 0 0 0 0 0
-          0 0 0 0 0 0
-          0 0 0 0 0 0
-          0 0 0 0 0 0
-          0 0 0 0 0 0
-          0 0 0 0 0 0
-          0 0 0 0 0 0
-          0 0 0 0 0 0
-          0 0 0 0 0 0
-          1 0 0 0 0 0
-          0 0 0 0 0 0
-          0 0 0 0 0 0
-          0 0 0 0 0 0
-          0 0 0 0 0 0
-          0 0 0 0 0 0
-          0 0 0 0 0 0
-          0 0 0 0 0 0
-          0
-        </DataArray>
-        <DataArray type="Int64" Name="geometry_set_11_point" format="ascii" RangeMin="0" RangeMax="1">
-          0 0 0 0 0 0
-          0 0 0 0 0 0
-          0 0 0 0 0 0
-          0 0 0 0 0 0
-          0 0 0 0 0 0
-          0 0 0 0 0 0
-          0 0 0 0 0 0
-          0 0 0 0 0 0
-          0 0 0 0 0 0
-          0 0 0 0 0 0
-          0 0 0 0 0 0
-          0 0 0 0 0 0
-          0 0 0 0 0 0
-          0 0 0 0 0 1
-          0 0 0 0 0 0
-          0 0 0 0 0 0
-          0 0 0 0 0 0
-          0 0 0 0 0 0
-          0 0 0 0 0 0
-          0 0 0 0 0 0
-          0
-        </DataArray>
-        <DataArray type="Int64" Name="geometry_set_12_point" format="ascii" RangeMin="0" RangeMax="1">
-          0 0 0 0 0 0
-          0 0 0 0 0 0
-          0 0 0 0 0 0
-          0 0 0 0 0 0
-          0 0 0 0 0 0
-          0 0 0 0 0 0
-          0 0 0 0 0 0
-          0 0 0 0 0 0
-          0 0 0 0 0 0
-          0 0 0 0 0 0
-          0 0 0 0 0 0
-          0 0 0 0 0 0
-          0 0 0 0 0 0
-          0 0 0 0 0 0
-          0 0 0 0 0 0
-          0 0 0 0 1 0
-          0 0 0 0 0 0
-          0 0 0 0 0 0
-          0 0 0 0 0 0
-          0 0 0 0 0 0
-          0
-        </DataArray>
-        <DataArray type="Int64" Name="geometry_set_13_point" format="ascii" RangeMin="0" RangeMax="1">
-          0 0 0 0 0 0
-          0 0 0 0 0 0
-          0 0 0 0 0 0
-          0 0 0 0 0 0
-          0 0 0 0 0 0
-          0 0 0 0 0 0
-          0 0 0 0 0 0
-          0 0 0 0 0 0
-          0 0 0 0 0 0
-          0 0 0 0 0 0
-          0 0 0 0 0 0
-          0 0 0 0 0 0
-          0 0 0 0 0 0
-          0 0 0 0 0 0
-          0 0 0 0 0 0
-          0 0 0 0 0 0
-          0 0 0 0 0 0
-          0 0 0 1 0 0
-          0 0 0 0 0 0
-          0 0 0 0 0 0
-          0
-        </DataArray>
-        <DataArray type="Int64" Name="geometry_set_14_point" format="ascii" RangeMin="0" RangeMax="1">
-          0 0 0 0 0 0
-          0 0 0 0 0 0
-          0 0 0 0 0 0
-          0 0 0 0 0 0
-          0 0 0 0 0 0
-          0 0 0 0 0 0
-          0 0 0 0 0 0
-          0 0 0 0 0 0
-          0 0 0 0 0 0
-          0 0 0 0 0 0
-          0 0 0 0 0 0
-          0 0 0 0 0 0
-          0 0 0 0 0 0
-          0 0 0 0 0 0
-          0 0 0 0 0 0
-          0 0 0 0 0 0
-          0 0 0 0 0 0
-          0 0 0 0 0 0
-          0 0 0 0 0 0
-          0 0 1 0 0 0
           0
         </DataArray>
         <DataArray type="Int64" Name="geometry_set_15_surface" format="ascii" RangeMin="1" RangeMax="1">


### PR DESCRIPTION
This PR fixes the geometry type of the lifted space-time node sets (they are line sets not point sets).