### PR TITLE
Use element sets instead for point sets for elements in space-time

### DIFF
--- a/src/beamme/core/element.py
+++ b/src/beamme/core/element.py
@@ -21,11 +21,15 @@
 # THE SOFTWARE.
 """This module implements the class that represents one element in the Mesh."""
 
+from beamme.core.conf import ElementType as _ElementType
 from beamme.core.material import Material as _Material
 
 
 class Element:
     """A base class for an FEM element in the mesh."""
+
+    # Type of this element.
+    element_type: _ElementType | None = None
 
     def __init__(self, nodes=None, material: _Material | None = None) -> None:
         # Global index of this element in a mesh.

--- a/src/beamme/core/geometry_set.py
+++ b/src/beamme/core/geometry_set.py
@@ -159,6 +159,11 @@ class GeometrySet(GeometrySetBase):
             return _bme.geo.line
         elif isinstance(item, GeometrySet):
             return item.geometry_type
+        elif (
+            isinstance(item, _Element)
+            and type(item).element_type == _bme.element_type.space_time_beam
+        ):
+            return _bme.geo.surface
         raise TypeError(f"Got unexpected type {type(item)}")
 
     def add(
@@ -229,17 +234,20 @@ class GeometrySet(GeometrySetBase):
             return list(
                 _cast(_KeysView[_Node], self.geometry_objects[_bme.geo.point].keys())
             )
-        elif self.geometry_type is _bme.geo.line:
+        elif (
+            self.geometry_type is _bme.geo.line
+            or self.geometry_type is _bme.geo.surface
+        ):
             nodes = []
             for element in _cast(
-                _KeysView[_Element], self.geometry_objects[_bme.geo.line].keys()
+                _KeysView[_Element], self.geometry_objects[self.geometry_type].keys()
             ):
                 nodes.extend(element.nodes)
             # Remove duplicates while preserving order
             return list(dict.fromkeys(nodes))
         else:
             raise TypeError(
-                "Currently GeometrySet is only implemented for points and lines"
+                "Currently GeometrySet is only implemented for points, lines and surfaces"
             )
 
     def get_geometry_objects(self) -> _Sequence[_Node | _Element]:

--- a/src/beamme/space_time/beam_to_space_time.py
+++ b/src/beamme/space_time/beam_to_space_time.py
@@ -32,6 +32,8 @@ from beamme.core.conf import bme as _bme
 from beamme.core.coupling import Coupling as _Coupling
 from beamme.core.element_volume import VolumeElement as _VolumeElement
 from beamme.core.geometry_set import GeometryName as _GeometryName
+from beamme.core.geometry_set import GeometrySet as _GeometrySet
+from beamme.core.geometry_set import GeometrySetBase as _GeometrySetBase
 from beamme.core.geometry_set import GeometrySetNodes as _GeometrySetNodes
 from beamme.core.mesh import Mesh as _Mesh
 from beamme.core.mesh_representation import MeshRepresentation as _MeshRepresentation
@@ -139,9 +141,11 @@ def beam_to_space_time(
     else:
         raise TypeError(f"Got unexpected element type {element_type}")
 
-    # Number the nodes in the original mesh
+    # Number nodes and elements in the original mesh
     for i_node, node in enumerate(mesh_space_reference.nodes):
         node.i_global = i_node
+    for i_element, element in enumerate(mesh_space_reference.elements):
+        element.i_global = i_element
 
     # Get the nodes for the final space-time mesh
     left_nodes: list[_Node] = []
@@ -261,31 +265,53 @@ def beam_to_space_time(
         _bme.geo.surface: _bme.geo.volume,
     }
     all_sets_in_space = mesh_space_reference.get_unique_geometry_sets()
-    space_time_geometry_sets = []
+    space_time_geometry_sets: list[_GeometrySetBase] = []
     for geometry_type, geometry_sets in all_sets_in_space.items():
         for geometry_set in geometry_sets:
             if geometry_set in coupling_geometry_sets:
                 # The coupling geometry sets are already handled above, so we skip them here.
                 continue
 
-            geometry_set_nodes = geometry_set.get_all_nodes()
-            raised_geometry_set_nodes = []
-            for node in geometry_set_nodes:
-                for i_mesh_space in range(number_of_copies_in_time):
-                    raised_geometry_set_nodes.append(
-                        space_time_nodes[
-                            node.i_global + i_mesh_space * number_of_nodes_in_space
-                        ]
+            if isinstance(geometry_set, _GeometrySet) and (
+                geometry_type == _bme.geo.line
+                or geometry_type == _bme.geo.surface
+                or geometry_type == _bme.geo.volume
+            ):
+                raised_geometry_set_elements = []
+                for element in geometry_set.get_geometry_objects():
+                    for i_element_row_in_time in range(number_of_elements_in_time):
+                        raised_geometry_set_elements.append(
+                            space_time_elements[
+                                element.i_global
+                                + i_element_row_in_time * number_of_elements_in_space
+                            ]
+                        )
+                space_time_geometry_sets.append(
+                    _GeometrySet(
+                        raised_geometry_set_elements,
+                        name=geometry_set.name,
                     )
-
-            geometry_type_raised = raise_geometry_type[geometry_type]
-            space_time_geometry_sets.append(
-                _GeometrySetNodes(
-                    geometry_type_raised,
-                    raised_geometry_set_nodes,
-                    name=geometry_set.name,
                 )
-            )
+
+            else:
+                geometry_set_nodes = geometry_set.get_all_nodes()
+                raised_geometry_set_nodes = []
+                for node in geometry_set_nodes:
+                    for i_mesh_space in range(number_of_copies_in_time):
+                        raised_geometry_set_nodes.append(
+                            space_time_nodes[
+                                node.i_global + i_mesh_space * number_of_nodes_in_space
+                            ]
+                        )
+
+                geometry_type_raised = raise_geometry_type[geometry_type]
+                space_time_geometry_sets.append(
+                    _GeometrySetNodes(
+                        geometry_type_raised,
+                        raised_geometry_set_nodes,
+                        name=geometry_set.name,
+                    )
+                )
 
     # Create the new mesh and add all the mesh items
     space_time_mesh = _Mesh()

--- a/tests/reference-files/test_integration_space_time_node_sets_linear.vtu
+++ b/tests/reference-files/test_integration_space_time_node_sets_linear.vtu
@@ -176,6 +176,21 @@
           6 7 8 9 10 11
           12 13 14 15 16 17
         </DataArray>
+        <DataArray type="Int64" Name="geometry_set_10_surface" format="ascii" RangeMin="0" RangeMax="1">
+          1 1 1 0 0 0
+          1 1 1 0 0 0
+          1 1 1 0 0 0
+        </DataArray>
+        <DataArray type="Int64" Name="geometry_set_11_surface" format="ascii" RangeMin="0" RangeMax="1">
+          0 0 0 1 1 0
+          0 0 0 1 1 0
+          0 0 0 1 1 0
+        </DataArray>
+        <DataArray type="Int64" Name="geometry_set_12_surface" format="ascii" RangeMin="0" RangeMax="1">
+          0 0 0 0 0 1
+          0 0 0 0 0 1
+          0 0 0 0 0 1
+        </DataArray>
         <DataArray type="Float64" Name="rotation_vector" NumberOfComponents="12" format="ascii" RangeMin="0" RangeMax="4.188790204786391">
           0 0 0 0 0 0
           0 0 0 0 0 0

--- a/tests/reference-files/test_integration_space_time_node_sets_linear_coupling.vtu
+++ b/tests/reference-files/test_integration_space_time_node_sets_linear_coupling.vtu
@@ -184,6 +184,21 @@
           6 7 8 9 10 11
           12 13 14 15 16 17
         </DataArray>
+        <DataArray type="Int64" Name="geometry_set_14_surface" format="ascii" RangeMin="0" RangeMax="1">
+          1 1 1 0 0 0
+          1 1 1 0 0 0
+          1 1 1 0 0 0
+        </DataArray>
+        <DataArray type="Int64" Name="geometry_set_15_surface" format="ascii" RangeMin="0" RangeMax="1">
+          0 0 0 1 1 0
+          0 0 0 1 1 0
+          0 0 0 1 1 0
+        </DataArray>
+        <DataArray type="Int64" Name="geometry_set_16_surface" format="ascii" RangeMin="0" RangeMax="1">
+          0 0 0 0 0 1
+          0 0 0 0 0 1
+          0 0 0 0 0 1
+        </DataArray>
         <DataArray type="Float64" Name="rotation_vector" NumberOfComponents="12" format="ascii" RangeMin="0" RangeMax="4.188790204786391">
           0 0 0 0 0 0
           0 0 0 0 0 0

--- a/tests/reference-files/test_integration_space_time_node_sets_quadratic.vtu
+++ b/tests/reference-files/test_integration_space_time_node_sets_quadratic.vtu
@@ -403,6 +403,21 @@
           6 7 8 9 10 11
           12 13 14 15 16 17
         </DataArray>
+        <DataArray type="Int64" Name="geometry_set_10_surface" format="ascii" RangeMin="0" RangeMax="1">
+          1 1 1 0 0 0
+          1 1 1 0 0 0
+          1 1 1 0 0 0
+        </DataArray>
+        <DataArray type="Int64" Name="geometry_set_11_surface" format="ascii" RangeMin="0" RangeMax="1">
+          0 0 0 1 1 0
+          0 0 0 1 1 0
+          0 0 0 1 1 0
+        </DataArray>
+        <DataArray type="Int64" Name="geometry_set_12_surface" format="ascii" RangeMin="0" RangeMax="1">
+          0 0 0 0 0 1
+          0 0 0 0 0 1
+          0 0 0 0 0 1
+        </DataArray>
         <DataArray type="Float64" Name="rotation_vector" NumberOfComponents="27" format="ascii" RangeMin="0" RangeMax="6.283185307179585">
           0 0 0 0 0 0
           0 0 0 0 0 0

--- a/tests/reference-files/test_integration_space_time_node_sets_quadratic_coupling.vtu
+++ b/tests/reference-files/test_integration_space_time_node_sets_quadratic_coupling.vtu
@@ -490,6 +490,21 @@
           6 7 8 9 10 11
           12 13 14 15 16 17
         </DataArray>
+        <DataArray type="Int64" Name="geometry_set_17_surface" format="ascii" RangeMin="0" RangeMax="1">
+          1 1 1 0 0 0
+          1 1 1 0 0 0
+          1 1 1 0 0 0
+        </DataArray>
+        <DataArray type="Int64" Name="geometry_set_18_surface" format="ascii" RangeMin="0" RangeMax="1">
+          0 0 0 1 1 0
+          0 0 0 1 1 0
+          0 0 0 1 1 0
+        </DataArray>
+        <DataArray type="Int64" Name="geometry_set_19_surface" format="ascii" RangeMin="0" RangeMax="1">
+          0 0 0 0 0 1
+          0 0 0 0 0 1
+          0 0 0 0 0 1
+        </DataArray>
         <DataArray type="Float64" Name="rotation_vector" NumberOfComponents="27" format="ascii" RangeMin="0" RangeMax="6.283185307179585">
           0 0 0 0 0 0
           0 0 0 0 0 0


### PR DESCRIPTION
With this PR, the space-time element sets are now handled consistently as element sets and not directly converted to "element sets defied by points" (another 4C specific...).