### PR TITLE
Improve dumping of boundary conditions

### DIFF
--- a/src/beamme/four_c/boundary_condition_data.py
+++ b/src/beamme/four_c/boundary_condition_data.py
@@ -1,0 +1,60 @@
+# The MIT License (MIT)
+#
+# Copyright (c) 2018-2026 BeamMe Authors
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+"""This file provides a data class to handle boundary conditions dumped to 4C input
+files."""
+
+from dataclasses import dataclass as _dataclass
+from typing import Any as _Any
+
+from beamme.core.mesh_representation import GeometrySetInfo as _GeometrySetInfo
+
+
+@_dataclass
+class FourCBoundaryConditionData:
+    """Class that contains the data for a 4C boundary condition."""
+
+    geometry_set_id: int
+    data: dict
+
+    def dump_to_input_file_yaml(self) -> dict:
+        """Dump the boundary condition data to a dictionary that can be written to a 4C
+        input file with the mesh in yaml format."""
+        return {"E": self.geometry_set_id, **self.data}
+
+    def dump_to_input_file_vtu(
+        self, geometry_sets_in_mr: dict[int, _GeometrySetInfo]
+    ) -> dict:
+        """Dump the boundary condition data to a dictionary that can be written to a 4C
+        input file with the mesh in vtu format."""
+        # For geometry sets in vtu format, 4C starts counting from 0. Also, the entries in geometry_sets_in_mr are indexed from 0.
+        geometry_set_id = self.geometry_set_id - 1
+        geometry_set_info = geometry_sets_in_mr[geometry_set_id]
+
+        boundary_condition_geometry_info: dict[str, _Any]
+        if geometry_set_info.name is not None:
+            boundary_condition_geometry_info = {"NODE_SET_NAME": geometry_set_info.name}
+        else:
+            boundary_condition_geometry_info = {
+                "E": geometry_set_id,
+                "ENTITY_TYPE": "node_set_id",
+            }
+        return {**boundary_condition_geometry_info, **self.data}

--- a/src/beamme/four_c/input_file.py
+++ b/src/beamme/four_c/input_file.py
@@ -22,6 +22,7 @@
 """This module defines the classes that are used to create an input file for 4C."""
 
 import os as _os
+from collections import defaultdict as _defaultdict
 from collections.abc import Callable as _Callable
 from datetime import datetime as _datetime
 from pathlib import Path as _Path
@@ -35,6 +36,9 @@ from fourcipp.utils.not_set import NOT_SET as _NOT_SET
 from beamme.core.conf import INPUT_FILE_HEADER as _INPUT_FILE_HEADER
 from beamme.core.mesh import Mesh as _Mesh
 from beamme.core.mesh_representation import MeshRepresentation as _MeshRepresentation
+from beamme.four_c.boundary_condition_data import (
+    FourCBoundaryConditionData as _FourCBoundaryConditionData,
+)
 from beamme.four_c.element_data import FourCElementData as _FourCElementData
 from beamme.four_c.input_file_dump_functions import (
     dump_mesh_representation_to_input_file_vtu as _dump_mesh_representation_to_input_file_vtu,
@@ -70,6 +74,11 @@ class InputFile:
         # Mesh representation for this input file.
         self.mesh_representation = _MeshRepresentation()
         self.element_type_id_to_data: dict[_Any, _FourCElementData] = {}
+
+        # Boundary conditions
+        self.boundary_conditions: dict[str, list[_FourCBoundaryConditionData]] = (
+            _defaultdict(list)
+        )
 
     def __contains__(self, key: str) -> bool:
         """Contains function.
@@ -164,6 +173,7 @@ class InputFile:
             fourc_input,
             self.mesh_representation,
             self.element_type_id_to_data,
+            self.boundary_conditions,
         )
         return fourc_input
 
@@ -238,7 +248,10 @@ class InputFile:
                 input_file_base_name + ".mesh.vtu"
             )
             vtu_grid = _dump_mesh_representation_to_input_file_vtu(
-                fourc_input, self.mesh_representation, self.element_type_id_to_data
+                fourc_input,
+                self.mesh_representation,
+                self.element_type_id_to_data,
+                self.boundary_conditions,
             )
             # Save the grid and add the file name to the input file
             vtu_grid.save(vtu_file_path, binary=vtu_binary)
@@ -248,6 +261,7 @@ class InputFile:
                 fourc_input,
                 self.mesh_representation,
                 self.element_type_id_to_data,
+                self.boundary_conditions,
             )
         else:
             raise ValueError(f"Unsupported mesh format: {mesh_format}.")

--- a/src/beamme/four_c/input_file_dump_functions.py
+++ b/src/beamme/four_c/input_file_dump_functions.py
@@ -47,6 +47,9 @@ from beamme.core.mesh_representation import (
 )
 from beamme.core.nurbs_patch import NURBSPatch as _NURBSPatch
 from beamme.core.rotation import Rotation as _Rotation
+from beamme.four_c.boundary_condition_data import (
+    FourCBoundaryConditionData as _FourCBoundaryConditionData,
+)
 from beamme.four_c.element_data import FourCElementData as _FourCElementData
 from beamme.four_c.four_c_types import (
     BeamKirchhoffParametrizationType as _BeamKirchhoffParametrizationType,
@@ -103,7 +106,7 @@ def dump_coupling(coupling):
 
         data = element_type.get_coupling_dict(coupling.data)
 
-    return {"E": coupling.geometry_set, **data}
+    return data
 
 
 def dump_nurbs_patch_knotvectors(input_file, nurbs_patch: _NURBSPatch) -> None:
@@ -310,13 +313,29 @@ def dump_mesh_to_input_file(input_file, mesh: _Mesh) -> None:
     for (bc_key, geometry_key), bc_list in mesh.boundary_conditions.items():
         if bc_list:
             if isinstance(bc_key, str):
-                _INPUT_FILE_MAPPINGS["known_boundary_condition_sections"].add(bc_key)
                 section = bc_key
             else:
                 section = _INPUT_FILE_MAPPINGS["boundary_conditions"][
                     (bc_key, geometry_key)
                 ]
-            _dump(section, bc_list)
+
+            for boundary_condition in bc_list:
+                if isinstance(boundary_condition, _BoundaryCondition):
+                    bc_data = boundary_condition.data
+                elif isinstance(boundary_condition, _Coupling):
+                    bc_data = dump_coupling(boundary_condition)
+                else:
+                    raise TypeError(
+                        f"Got unexpected type {type(boundary_condition)} for boundary condition"
+                    )
+                input_file.boundary_conditions[section].append(
+                    _FourCBoundaryConditionData(
+                        geometry_set_id=input_file.fourc_input.type_converter(
+                            boundary_condition.geometry_set
+                        ),
+                        data=input_file.fourc_input.type_converter(bc_data),
+                    )
+                )
 
     # If we have previously set the node links, we unlink them here.
     if is_linked_nodes:
@@ -332,6 +351,7 @@ def dump_mesh_representation_to_input_file_yaml(
     fourc_input: _FourCInput,
     mesh_representation: _MeshRepresentation,
     element_type_id_to_data: dict[int, _FourCElementData],
+    boundary_conditions: dict[str, list[_FourCBoundaryConditionData]],
 ) -> None:
     """Dump the information contained in the mesh representation to the 4C input file
     via FourCIPP, in yaml format.
@@ -340,6 +360,7 @@ def dump_mesh_representation_to_input_file_yaml(
         fourc_input: 4C input file via FourCIPP where the mesh information data will be dumped to.
         mesh_representation: The mesh representation that is added to the input file.
         element_type_id_to_data: The mapping between element type ID and the element type data.
+        boundary_conditions: The boundary conditions in the input file.
     """
     # Compute the starting indices for the nodes and elements entities.
     start_index_nodes = len(fourc_input.sections.get("NODE COORDS", []))
@@ -488,11 +509,19 @@ def dump_mesh_representation_to_input_file_yaml(
             geometry_set_list,
         )
 
+    # Add the boundary conditions to the input file.
+    for section, input_file_bc in boundary_conditions.items():
+        bc_list = fourc_input.pop(section, [])
+        for boundary_condition in input_file_bc:
+            bc_list.append(boundary_condition.dump_to_input_file_yaml())
+        fourc_input.combine_sections({section: bc_list})
+
 
 def dump_mesh_representation_to_input_file_vtu(
     fourc_input: _FourCInput,
     mesh_representation: _MeshRepresentation,
     element_type_id_to_data: dict[int, _FourCElementData],
+    boundary_conditions: dict[str, list[_FourCBoundaryConditionData]],
 ) -> _pv.UnstructuredGrid:
     """Dump the input file to a vtu mesh data format.
 
@@ -508,6 +537,7 @@ def dump_mesh_representation_to_input_file_vtu(
         mesh_representation: The mesh representation that is added to the input file.
         element_type_id_to_data: The mapping between element type ID and the element
             type data.
+        boundary_conditions: The boundary conditions in the input file.
 
     Returns:
         The unstructured grid containing the vtu mesh.
@@ -645,20 +675,15 @@ def dump_mesh_representation_to_input_file_vtu(
                 )
             grid.point_data[data_array_name] = values
 
-    # Boundary conditions must reference geometry sets stored in the VTU file.
-    known_bc_sections = _INPUT_FILE_MAPPINGS["known_boundary_condition_sections"]
-    for section in list(fourc_input.sections):
-        if section in known_bc_sections:
-            boundary_conditions = fourc_input.pop(section)
-            for boundary_condition in boundary_conditions:
-                geometry_set_id = boundary_condition.pop("E") - 1
-                geometry_set_info = geometry_sets_in_mr[geometry_set_id]
-                if geometry_set_info.name is not None:
-                    boundary_condition["NODE_SET_NAME"] = geometry_set_info.name
-                else:
-                    boundary_condition["E"] = geometry_set_id
-                    boundary_condition["ENTITY_TYPE"] = "node_set_id"
-            fourc_input.combine_sections({section: boundary_conditions})
+    # Add definition of the boundary conditions (geometry sets defined in the vtu
+    # mesh) to the yaml input file.
+    for section, input_file_bc in boundary_conditions.items():
+        bc_list = fourc_input.pop(section, [])
+        for boundary_condition in input_file_bc:
+            bc_list.append(
+                boundary_condition.dump_to_input_file_vtu(geometry_sets_in_mr)
+            )
+        fourc_input.combine_sections({section: bc_list})
 
     # Return the vtu grid.
     return grid

--- a/src/beamme/four_c/input_file_mappings.py
+++ b/src/beamme/four_c/input_file_mappings.py
@@ -167,14 +167,6 @@ INPUT_FILE_MAPPINGS["boundary_conditions"] = {
         _bme.geo.surface,
     ): "DESIGN SURF MORTAR CONTACT CONDITIONS 3D",
 }
-# The definition of boundary conditions in 4C depends on the type of mesh output
-# (e.g., yaml or external mesh). When the actual input file is dumped, the correct
-# definition for geometry sets has to be used. BeamMe does not know all possible
-# boundary condition sections in advance, therefore, we store all used boundary
-# condition sections here, so we can check against them when dumping the input file.
-INPUT_FILE_MAPPINGS["known_boundary_condition_sections"] = set(
-    INPUT_FILE_MAPPINGS["boundary_conditions"].values()
-)
 INPUT_FILE_MAPPINGS["geometry_sets_geometry_to_condition_name"] = {
     _bme.geo.point: "DNODE-NODE TOPOLOGY",
     _bme.geo.line: "DLINE-NODE TOPOLOGY",

--- a/tests/conftest_result_comparison.py
+++ b/tests/conftest_result_comparison.py
@@ -178,7 +178,10 @@ def convert_to_primitive_type(
         elif four_c_input_file_data_format == "vtu":
             fourc_input = obj.fourc_input.copy()
             vtu_grid = dump_mesh_representation_to_input_file_vtu(
-                fourc_input, obj.mesh_representation, obj.element_type_id_to_data
+                fourc_input,
+                obj.mesh_representation,
+                obj.element_type_id_to_data,
+                obj.boundary_conditions,
             )
             # Add the grid to the dictionary containing the input file information
             fourc_input["STRUCTURE GEOMETRY"]["FILE"] = vtu_grid


### PR DESCRIPTION
For 4C, the boundary condition sections in the input file look different if the mesh is in legacy yaml format or in vtu.

Thus, we need to create the correct data structure when dumping the input file. This required us to abuse the entry `INPUT_FILE_MAPPINGS["known_boundary_condition_sections"]` to track which sections in the input file are boundary conditions.

This behaviour is now cleaned up. When dumping a mesh to an input file, we convert each BeamMe boundary condition in a suitable data structure that can then easily be used for dumping to yaml/vtu later on.