### PR TITLE
Make vtu mesh output the default for 4C

### DIFF
--- a/src/beamme/four_c/input_file.py
+++ b/src/beamme/four_c/input_file.py
@@ -181,7 +181,7 @@ class InputFile:
         self,
         input_file_path: str | _Path,
         *,
-        mesh_format: str = "yaml",
+        mesh_format: str = "vtu",
         vtu_binary: bool = False,
         nox_xml_file: str | None = None,
         add_header_default: bool = True,

--- a/tests/conftest_result_comparison.py
+++ b/tests/conftest_result_comparison.py
@@ -293,6 +293,7 @@ def handle_failed_assertion(
 
     result.dump(
         result_path,
+        mesh_format="yaml",
         add_header_default=False,
         add_header_information=False,
         add_footer_application_script=False,

--- a/tests/create_structured_exodus_hex_mesh.py
+++ b/tests/create_structured_exodus_hex_mesh.py
@@ -311,6 +311,7 @@ def create_exodus_input_file(
     )
     input_file.dump(
         input_file_path,
+        mesh_format="yaml",
         validate_sections_only=True,
         add_header_default=False,
         add_header_information=False,

--- a/tests/integration/test_integration_four_c.py
+++ b/tests/integration/test_integration_four_c.py
@@ -256,6 +256,7 @@ def test_integration_four_c_nurbs_import(
     nurbs_path = tmp_path / "nurbs_mesh.4C.yaml"
     nurbs_input_file.dump(
         nurbs_path,
+        mesh_format="yaml",
         validate=False,
         add_header_default=False,
         add_header_information=False,

--- a/tests/integration/test_integration_four_c_header_functions.py
+++ b/tests/integration/test_integration_four_c_header_functions.py
@@ -205,6 +205,7 @@ def test_integration_four_c_header_functions_nonlinear_solver_parameters(
     temp_input_file_path = tmp_path / "nonlinear_solver_parameters.4C.yaml"
     input_file.dump(
         temp_input_file_path,
+        mesh_format="yaml",
         nox_xml_file=nox_xml_file_kwarg,
         add_header_default=False,
         add_header_information=False,

--- a/tests/integration/test_integration_four_c_simulation.py
+++ b/tests/integration/test_integration_four_c_simulation.py
@@ -111,7 +111,8 @@ def run_four_c_test(tmp_path: Path) -> Callable:
         input_file: InputFile,
         n_proc: int = 2,
         restart: list[int | str | None] = [None, None],
-        **kwargs,
+        mesh_format: str | None = None,
+        nox_xml_file: str | None = None,
     ) -> tuple[Path, str]:
         """Runs a 4C simulation inside a temporary test directory.
 
@@ -120,14 +121,18 @@ def run_four_c_test(tmp_path: Path) -> Callable:
         Args:
             input_file: The input file to execute.
             n_proc: Number of MPI processes to launch 4C with. Defaults to 2.
-            restart: A two-element list of the form ``[restart_step, restart_from]``.
-                Defaults to ``[None, None]``.
-            **kwargs: Additional arguments passed directly to ``InputFile.dump()``.
+            restart: A two-element list of the form `[restart_step, restart_from]`.
+                Defaults to `[None, None]`.
+            mesh_format: Mesh format to use for the simulation. Has to be provide.
+            nox_xml_file: The path to the NOX XML file. Defaults to `None`.
 
         Returns:
             run_dir: The directory where the simulation ran.
             run_name: The name of the 4C run.
         """
+        if mesh_format is None:
+            raise ValueError("Please provide a mesh format to `run_four_c_test`.")
+
         # Since the counter is of a base type, we have to use nonlocal to modify it.
         nonlocal run_four_c_counter
         run_four_c_counter += 1
@@ -139,7 +144,12 @@ def run_four_c_test(tmp_path: Path) -> Callable:
 
         # Create input file.
         input_file_name = os.path.join(run_dir, run_name + ".4C.yaml")
-        input_file.dump(input_file_name, add_header_information=False, **kwargs)
+        input_file.dump(
+            input_file_name,
+            add_header_information=False,
+            mesh_format=mesh_format,
+            nox_xml_file=nox_xml_file,
+        )
 
         return_code = run_four_c(
             input_file_name,

--- a/tests/other/test_other_create_cubit_input_files.py
+++ b/tests/other/test_other_create_cubit_input_files.py
@@ -80,7 +80,10 @@ def test_other_create_cubit_input_files_solid_shell_blocks(
 
     input_file = create_solid_shell_blocks()
     input_file.dump(
-        result_path_blocks, add_header_information=False, validate_sections_only=True
+        result_path_blocks,
+        mesh_format="yaml",
+        add_header_information=False,
+        validate_sections_only=True,
     )
 
     assert_results_close(result_path_blocks, reference_path_blocks)


### PR DESCRIPTION
This PR proposes to change the default mesh format for 4C input files to `vtu`.

@davidrudlstorfer I thought about the `auto` option, but I am not sure if this really makes sense as it is quire arbitrary. If the user wants a pure yaml output for debugging purposes, one can simply activate it.

Note, this should work fine for all discretizations, except NURBS. Furthermore, this might be a breaking change for some downstream scripts.