### PR TITLE
Make binary vtu output the default

### DIFF
--- a/src/beamme/four_c/input_file.py
+++ b/src/beamme/four_c/input_file.py
@@ -182,7 +182,7 @@ class InputFile:
         input_file_path: str | _Path,
         *,
         mesh_format: str = "vtu",
-        vtu_binary: bool = False,
+        vtu_binary: bool = True,
         nox_xml_file: str | None = None,
         add_header_default: bool = True,
         add_header_information: bool = True,


### PR DESCRIPTION
Switch the default data structure for vtu output from ascii to binary. This saves a lot of space for larger models.